### PR TITLE
Major Feature (2020-05): Better Buffer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ libc = "0.2.60"
 winapi = { version =  "0.3.7", features = ["wincon", "winbase", "winuser", "winnt", "consoleapi", "processenv", "handleapi"] }
 
 [lib]
-crate-type = ["cdylib", "lib"]
+crate-type = ["lib"]

--- a/examples/grapheme_ex.rs
+++ b/examples/grapheme_ex.rs
@@ -54,7 +54,8 @@ fn main() {
                          modified_ka,
                          devanagari,
                          devanagari_manual,
-                         esc_chars,
+                         // esc_chars,
+                         "",
                          ascii_cjk_mix,
                          wide_symbol);
 
@@ -177,5 +178,5 @@ fn main() {
             }
         }}
     }
-    println!("output: \"{:?}\"", string);
+    println!("output: \"{}\"", string);
 }

--- a/examples/grapheme_ex.rs
+++ b/examples/grapheme_ex.rs
@@ -1,14 +1,14 @@
 extern crate tuitty;
+use tuitty::common::unicode::wcwidth::UnicodeWidthChar;
 use tuitty::common::unicode::grapheme::UnicodeGraphemes;
-use tuitty::common::unicode::wcwidth::UnicodeWidthStr;
 
-use std::{ thread, time::Duration };
+// use std::{ thread, time::Duration };
 
-#[cfg(unix)]
-use tuitty::terminal::actions::posix;
+// #[cfg(unix)]
+// use tuitty::terminal::actions::posix;
 
-#[cfg(windows)]
-use tuitty::terminal::actions::win32;
+// #[cfg(windows)]
+// use tuitty::terminal::actions::win32;
 
 
 fn main() {
@@ -34,25 +34,170 @@ fn main() {
     //     println!("{}", n.is_ascii());
     // }
 
-    #[cfg(unix)] {
-        let initial = posix::get_mode();
+    // #[cfg(unix)] {
+    //     let initial = posix::get_mode();
 
-        posix::enable_alt();
-        posix::raw();
+    //     posix::enable_alt();
+    //     posix::raw();
 
-        posix::goto(0, 0);
-        posix::printf("He㓘o, क्‍ष");
-        posix::goto(2, 0);
-        posix::flush();
-        thread::sleep(Duration::from_secs(2));
-        posix::goto(7, 0);
-        posix::flush();
-        thread::sleep(Duration::from_secs(2));
+    //     posix::goto(0, 0);
+    //     posix::printf("He㓘o, क्‍ष");
+    //     posix::goto(2, 0);
+    //     posix::flush();
+    //     thread::sleep(Duration::from_secs(2));
+    //     posix::goto(7, 0);
+    //     posix::flush();
+    //     thread::sleep(Duration::from_secs(2));
 
-        posix::cook(&initial);
-        posix::disable_alt();
-        thread::sleep(Duration::from_secs(1));
+    //     posix::cook(&initial);
+    //     posix::disable_alt();
+    //     thread::sleep(Duration::from_secs(1));
+    // }
+
+    let compound_emojis = ["👦🏿", "👩‍🔬", "👨‍👩‍👦"];
+    let zero_width_joiner = "\u{200d}";
+    // let virama_modifier = "् \u{94d}";
+    let basic_escapes = ["\t", "\0", "\n", "\r", "\r\n"];
+    let ascii_cjk_mix = "He㓘o";
+    let wide_symbol = "。。。";
+
+    // Returns the character's displayed width in columns, or `None` if the
+    // character is a control character other than `'\x00'`.
+
+    let emojis = format!("{}{}{}",
+                         compound_emojis[0],
+                         compound_emojis[1],
+                         compound_emojis[2]);
+    let zwjs = format!("{}{}{}",
+                       zero_width_joiner,
+                       zero_width_joiner,
+                       zero_width_joiner);
+    let modified_ka = "\u{915}\u{94d}";
+    let esc_chars = format!("{}{}{}{}{}",
+                            basic_escapes[0],
+                            basic_escapes[1],
+                            basic_escapes[2],
+                            basic_escapes[3],
+                            basic_escapes[4]);
+
+    let string = format!("{} {} {} {} {} {}",
+                         emojis,
+                         zwjs,
+                         modified_ka,
+                         esc_chars,
+                         ascii_cjk_mix,
+                         wide_symbol);
+
+    let mut graphemes = UnicodeGraphemes
+        ::graphemes(string.as_str(), true);
+
+    while let Some(s) = graphemes.next() {
+        let mut chars = s.chars().peekable();
+        if let Some(car) = chars.next() { match chars.peek() {
+            // A single grapheme - can be ascii, cjk, or escape seq:
+            None => match car.width() {
+                // Ascii or CJK
+                Some(w) => match w {
+                    0 => continue,
+                    1 => {
+                        if car == ' ' { println!("Content::Blank") }
+                        else { println!("Content::Single({})", car) }
+                    },
+                    2 => println!("Content::Double({})", car),
+                    _ => println!("Content::Unsupported"),
+                },
+                // Escape character
+                None => match car {
+                    '\t' => println!("Content::Tab"),
+                    '\n' => println!("Content::LF"),
+                    '\r' => println!("Content::CR"),
+                    _ => unreachable!(),
+                }
+            },
+            // A complex grapheme - can be emoji, CRLF, or language:
+            Some(cadr) => match (car, cadr) {
+                ('\r', '\n') => println!("Content::CRLF"),
+                _ => {
+                    let mut width = car.width().unwrap_or(0);
+                    let mut content = vec![car];
+                    loop {
+                        if let Some(next) = chars.next() {
+                            // Continue iterating through grapheme cluster:
+                            content.push(next);
+                            width += next.width().unwrap_or(0);
+                        } else {
+                            // End of grapheme - check if there is a joiner:
+                            if let Some(c) = content.last() { match c {
+                                '\u{200d}' => if let Some(s) = graphemes
+                                    .next() {
+                                        chars = s.chars().peekable();
+                                        continue;
+                                    },
+                                _ => break,
+                            }}
+                        }
+                    }
+                    let zwj_enabled = false;
+                    if zwj_enabled {
+                        println!("Content::Complex({:?}", content);
+                        println!("Content::Link(L: -1, R: +1)");
+                    } else {
+                        println!("Content::Complex({:?})", content);
+                        for i in 0..width {
+                            println!("Content::Link(L: -{}, R: {})",
+                                     i + 1, width - i);
+                        }
+                    }
+                }
+            }
+        }}
+        // let f = chars.next().unwrap_or('\0');
+        // if f == '\0' {
+        //     println!("Content::NULL");
+        //     continue;
+        // }
+        // match chars.peek() {
+        //     Some(t) => {
+        //         match (f, t) {
+        //             ('\r', '\n') => println!("Content::CRLF"),
+        //             _ => {
+        //                 // Complex Unicode
+        //                 let mut content = vec![f];
+        //                 loop {
+        //                     content.extend(chars.collect::<Vec<char>>());
+        //                     if content[content.len() - 1] == '\u{200d}' {
+        //                         match graphemes.next() {
+        //                             Some(s) => {
+        //                                 chars = s.chars().peekable();
+        //                                 continue;
+        //                             },
+        //                             None => break,
+        //                         }
+        //                     } else { break; }
+        //                 }
+        //                 println!("Content::Complex({:?})", content);
+        //             }
+        //         }
+        //     },
+        //     None => match s.width() {
+        //         1 => {
+        //             // if space --> blank
+        //             match f {
+        //                 ' ' => println!("Content::SPC"),
+        //                 _ => println!("Content::Single({})", f)
+        //             }
+        //         },
+        //         2 => println!("Content::Double({})", f),
+        //         _ => {
+        //             match f {
+        //                 '\t' => println!("Content::Tab"),
+        //                 '\n' => println!("Content::LF"),
+        //                 '\r' => println!("Content::CR"),
+        //                 _ => println!("Content::Unknown({:?})", f)
+        //             }
+        //         }
+        //     }
+        // }
     }
-
-
+    println!("output: \"{:?}\"", string);
 }

--- a/examples/grapheme_ex.rs
+++ b/examples/grapheme_ex.rs
@@ -1,5 +1,5 @@
 extern crate tuitty;
-use tuitty::common::unicode::wcwidth::UnicodeWidthChar;
+use tuitty::common::unicode::wcwidth::*;
 use tuitty::common::unicode::grapheme::UnicodeGraphemes;
 
 // use std::{ thread, time::Duration };
@@ -12,10 +12,13 @@ use tuitty::common::unicode::grapheme::UnicodeGraphemes;
 
 fn main() {
     // let original_input = "---- 👦🏿 ----";
-    let original_input = "---- 👨🏿‍🦰 ----";
-    let mut graphemes = UnicodeGraphemes::graphemes(original_input, true);
+    // let original_input = "---- 👨🏿‍🦰 ----";
+    // let original_input = "---- ⚠️ ----";
+    // let original_input= "---- ❤️ ----";
+    let original_input = "---- 👨‍👩‍👧 ----";
+    let graphemes = UnicodeGraphemes::graphemes(original_input, true);
     for g in graphemes {
-        println!("grapheme: {:?}, size: {}", g, std::mem::size_of_val(g));
+        println!("grapheme: {:?}, size: {}, width: {}", g, std::mem::size_of_val(g), g.width());
     }
 
 }

--- a/examples/grapheme_ex.rs
+++ b/examples/grapheme_ex.rs
@@ -12,54 +12,12 @@ use tuitty::common::unicode::grapheme::UnicodeGraphemes;
 
 
 fn main() {
-    // let c = "क्‍ष 👪 👨👩‍👧‍👦 🤦♀";
-    // println!("{}", c.width());
-    // let clusters = c.graphemes(true).collect::<Vec<&str>>();
-    // for c in clusters {
-    //     println!("{:?}: {:?}", c, c.width());
-    // }
-    // let c = 'क';
-    // let d = '्';
-    // let e = 'ष';
-
-    // println!("h{}{}{}h", c, d, e);
-
-    // let fp = "|🤦‍♀️|";
-    // println!("{}", fp);
-
-    // let content = "\x1B\t\r\n";
-    // let clusters = content.graphemes(true).collect::<Vec<&str>>();
-    // println!("{:?}", clusters);
-    // for n in clusters {
-    //     println!("{}", n.is_ascii());
-    // }
-
-    // #[cfg(unix)] {
-    //     let initial = posix::get_mode();
-
-    //     posix::enable_alt();
-    //     posix::raw();
-
-    //     posix::goto(0, 0);
-    //     posix::printf("He㓘o, क्‍ष");
-    //     posix::goto(2, 0);
-    //     posix::flush();
-    //     thread::sleep(Duration::from_secs(2));
-    //     posix::goto(7, 0);
-    //     posix::flush();
-    //     thread::sleep(Duration::from_secs(2));
-
-    //     posix::cook(&initial);
-    //     posix::disable_alt();
-    //     thread::sleep(Duration::from_secs(1));
-    // }
-
     let compound_emojis = ["👦🏿", "👩‍🔬", "👨‍👩‍👦", "👪", "👪🏽", "👨🏽‍👩🏽‍👧🏽"];
     let zero_width_joiner = "\u{200d}";
     // let virama_modifier = "् \u{94d}";
-    let basic_escapes = ["\t", "\0", "\n", "\r", "\r\n"];
+    let basic_escapes = ["\t", "\0", "\x1b]34m", "\n", "\r", "\r\n"];
     let ascii_cjk_mix = "He㓘o";
-    let wide_symbol = "。。。";
+    let wide_symbol = "。。。👪";
 
     let emojis = format!("{}{}{}{}{}{}",
                          compound_emojis[0],
@@ -75,12 +33,13 @@ fn main() {
     let modified_ka = "\u{915}\u{94d}";
     let devanagari = "क्‍ष";
     let devanagari_manual = "\u{915}\u{94d}\u{200d}\u{937}";
-    let esc_chars = format!("{}{}{}{}{}",
+    let esc_chars = format!("{}{}{}{}{}{}",
                             basic_escapes[0],
                             basic_escapes[1],
                             basic_escapes[2],
                             basic_escapes[3],
-                            basic_escapes[4]);
+                            basic_escapes[4],
+                            basic_escapes[5]);
 
     let string = format!("{} {} {} {} {} {} {} {}",
                          emojis,
@@ -105,7 +64,7 @@ fn main() {
             None => match car.width() {
                 // Ascii or CJK
                 Some(w) => match w {
-                    0 => continue,
+                    0 => println!("Content::Zero({:?})", car),
                     1 => {
                         if car == ' ' { println!("Content::Blank") }
                         else { println!("Content::Single({})", car) }
@@ -118,7 +77,7 @@ fn main() {
                     '\t' => println!("Content::Tab"),
                     '\n' => println!("Content::LF"),
                     '\r' => println!("Content::CR"),
-                    _ => unreachable!(),
+                    _ => println!("Content::Esc({:?})", car),
                 }
             },
             // A complex grapheme - can be emoji, CRLF, or language:

--- a/examples/grapheme_ex.rs
+++ b/examples/grapheme_ex.rs
@@ -10,8 +10,17 @@ use tuitty::common::unicode::grapheme::UnicodeGraphemes;
 // #[cfg(windows)]
 // use tuitty::terminal::actions::win32;
 
-
 fn main() {
+    // let original_input = "---- 👦🏿 ----";
+    let original_input = "---- 👨🏿‍🦰 ----";
+    let mut graphemes = UnicodeGraphemes::graphemes(original_input, true);
+    for g in graphemes {
+        println!("grapheme: {:?}, size: {}", g, std::mem::size_of_val(g));
+    }
+
+}
+
+fn _main() {
     let compound_emojis = ["👦🏿", "👩‍🔬", "👨‍👩‍👦", "👪", "👪🏽", "👨🏽‍👩🏽‍👧🏽",
                            "👨‍🦰", "🧗🏾‍♂\u{fe0f}", "🧗🏾‍♀\u{fe0f}",
                            "🕵🏼‍♀\u{fe0f}"];
@@ -48,16 +57,17 @@ fn main() {
                             basic_escapes[5]);
 
     // let string = format!("{} {} {} {} {} {} {} {}",
-    let string = format!("{} {} {} {} {} {} {}",
-                         emojis,
-                         // zwjs,
-                         modified_ka,
-                         devanagari,
-                         devanagari_manual,
-                         // esc_chars,
-                         "",
-                         ascii_cjk_mix,
-                         wide_symbol);
+    // let string = format!("{} {} {} {} {} {} {}",
+    //                      emojis,
+    //                      // zwjs,
+    //                      modified_ka,
+    //                      devanagari,
+    //                      devanagari_manual,
+    //                      // esc_chars,
+    //                      "",
+    //                      ascii_cjk_mix,
+    //                      wide_symbol);
+    let string = String::from("---- 👨🏿‍🦰 ----");
 
     let mut graphemes = UnicodeGraphemes
         ::graphemes(string.as_str(), true).peekable();
@@ -161,6 +171,13 @@ fn main() {
                         }
                     }
 
+                    let pred = |m: &char| *m == '\u{200d}';
+                    let slice = content.split(pred).next();
+                    let mut cutoff = 0;
+                    for c in slice.unwrap_or(&[]) {
+                        cutoff += c.len_utf8();
+                    }
+                    println!("cutoff: {}", cutoff);
                     let zwj_enabled = false;
                     if zwj_enabled {
                         println!("Content::Complex({:?} | width: 2", content);

--- a/examples/grapheme_support.rs
+++ b/examples/grapheme_support.rs
@@ -1,0 +1,61 @@
+use std::io::{self, Write, BufRead};
+
+
+fn pos_raw() -> (i16, i16) {
+    let ln = 4;
+    // Where is the cursor?
+    // Use `ESC [ 6 n`.
+    let mut stdout = io::stdout();
+    let stdin = io::stdin();
+
+    // Write command
+    stdout.write_all(b"\x1B[6n").expect(&format!(
+        "buffer.rs [Ln: {}]: Error writing to stdout", ln + 9));
+    stdout.flush().expect(&format!(
+        "buffer.rs [Ln: {}]: Error flushing stdout", ln + 11));
+
+    stdin.lock().read_until(b'[', &mut vec![]).expect(&format!(
+        "buffer.rs [Ln {}]: Error reading stdin", ln + 14));
+
+    let mut rows = vec![];
+    stdin.lock().read_until(b';', &mut rows).expect(&format!(
+        "buffer.rs [Ln {}]: Error reading stdin", ln + 18));
+
+    let mut cols = vec![];
+    stdin.lock().read_until(b'R', &mut cols).expect(&format!(
+        "buffer.rs [Ln {}]: Error reading stdin", ln + 22));
+
+    // remove delimiter
+    rows.pop();
+    cols.pop();
+
+    let rows = rows
+        .into_iter()
+        .map(|b| (b as char))
+        .fold(String::new(), |mut acc, n| {
+            acc.push(n);
+            acc
+        })
+        .parse::<usize>()
+        .expect(&format!(
+            "buffer.rs [Ln {}]: Error parsing row position.", ln + 29
+        ));
+    let cols = cols
+        .into_iter()
+        .map(|b| (b as char))
+        .fold(String::new(), |mut acc, n| {
+            acc.push(n);
+            acc
+        })
+        .parse::<usize>()
+        .expect(&format!(
+            "buffer.rs [Ln {}]: Error parsing col position.", ln + 40
+        ));
+
+    ((cols - 1) as i16, (rows - 1) as i16)
+}
+
+
+fn main() {
+    let check = "";
+}

--- a/examples/lr_scroll_perf.rs
+++ b/examples/lr_scroll_perf.rs
@@ -1,0 +1,240 @@
+use std::io::{stdout, BufWriter, Write};
+use std::thread;
+use std::time::Duration;
+
+
+
+#[cfg(unix)]
+use libc::{
+    cfmakeraw, tcgetattr, tcsetattr,
+    STDIN_FILENO, TCSANOW, termios as Termios
+};
+
+#[cfg(unix)]
+use std::{ mem, io::{ Error, Result } };
+
+
+fn prints(content: &str) {
+    let output = stdout();
+    let lock = output.lock();
+    let mut outbuf = BufWriter::new(lock);
+    outbuf.write_all(content.as_bytes()).expect("I/O error on write");
+}
+
+fn flush() {
+    let output = stdout();
+    let lock = output.lock();
+    let mut outbuf = BufWriter::new(lock);
+    outbuf.flush().expect("I/O error on flush");
+}
+
+fn printf(content: &str) {
+    let output = stdout();
+    let lock = output.lock();
+    let mut outbuf = BufWriter::new(lock);
+    outbuf.write_all(content.as_bytes()).expect("I/O error on write");
+    outbuf.flush().expect("I/O error on flush");
+}
+
+fn goto(col: i16, row: i16) -> String {
+    format!("\x1B[{};{}H", row + 1, col + 1)
+}
+
+
+
+fn enable_alt() -> String {
+    "\x1B[?1049h".to_string()
+}
+
+fn disable_alt() -> String {
+    "\x1B[?1049l".to_string()
+}
+
+#[cfg(unix)]
+fn get_mode() -> Result<Termios> {
+    unsafe {
+        let mut termios = mem::zeroed();
+        if tcgetattr(STDIN_FILENO, &mut termios) == -1 {
+            Err(Error::last_os_error())
+        } else {
+            Ok(termios)
+        }
+    }
+}
+
+/// This function enables raw mode in the current screen.
+#[cfg(unix)]
+fn enable_raw() -> Result<()> {
+    unsafe {
+        // Get the current terminal attrs.
+        let mut termios = get_mode()?;
+        // Apply the raw attr to the current terminal attrs.
+        // There is no effect until a subsequent call to tcsetattr().
+        // https://www.mkssoftware.com/docs/man3/cfmakeraw.3.asp
+        cfmakeraw(&mut termios);
+        // Set the current terminal with raw-enabled attrs.
+        // unwrap(tcsetattr(0, 0, &termios)).and(Ok(()))
+        set_mode(&termios)?;
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+fn set_mode(termios: &Termios) -> Result<()> {
+    if unsafe { tcsetattr(STDIN_FILENO, TCSANOW, termios) } == -1 {
+        Err(Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+fn main() {
+    // Null printing test (to see if it skips chars)
+    // printf(&"\n".repeat(30));
+    // prints(&goto(0, 4));
+    // printf("Hello, world");
+    // prints(&goto(0, 4));
+
+    // thread::sleep(Duration::from_millis(2000));
+    // printf("\0\0\0ttt\0\0\0a\0f");
+    // thread::sleep(Duration::from_millis(2000));
+
+
+    let mode = get_mode().unwrap();
+
+    printf(&enable_alt());
+    let _ = enable_raw();
+
+    // DCH test with emoji and cjk
+    printf(&goto(85, 29));
+    printf("X");
+    // printf("\x1B[4h");
+    printf(&goto(73, 0));
+    thread::sleep(Duration::from_millis(400));
+    // printf("👨‍👩‍👦");
+    // printf("o園o明");
+    printf("Hello, world!😀你好 yay!");
+    thread::sleep(Duration::from_millis(1000));
+    printf(&goto(80, 0));
+    thread::sleep(Duration::from_millis(1000));
+    // printf("whale!Go US");
+    // printf("\x1B[2P");
+    // printf("\x1B[4l");
+    thread::sleep(Duration::from_millis(2000));
+
+
+    // VT100 Left/Right Scrolling
+    // {
+    //     let s = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGH";
+    //     prints(&goto(0, 0));
+    //     for i in 0..30 {
+    //         prints(s);
+    //     }
+    //     flush();
+    //     thread::sleep(Duration::from_millis(2000));
+
+    //     // Right Scroll (DCH) 5
+    //     // Part 0 - highlight delete region
+    //     for i in 0..30 {
+    //         prints(&goto(0, i));
+    //         prints("\x1B[31mabcde\x1B[39m");
+    //     }
+    //     flush();
+    //     thread::sleep(Duration::from_millis(2000));
+
+    //     // Part 1 - delete
+    //     prints(&goto(0, 0));
+    //     for _ in 0..30 {
+    //         printf("\x1B[5P\x1B[B"); // DCH
+    //     }
+    //     // Part 2 - fill right side
+    //     for i in 0..30 {
+    //         prints(&goto(81, i));
+    //         prints("\x1b[32mIJKLM\x1b[39m");
+    //     }
+    //     flush();
+    //     thread::sleep(Duration::from_millis(2000));
+
+
+    //     // Left Scroll (ICH) 5
+    //     // Part 0 - highlight delete region
+    //     for i in 0..30 {
+    //         prints(&goto(81, i));
+    //         prints("\x1B[31mIJKLM\x1B[39m");
+    //     }
+    //     flush();
+    //     thread::sleep(Duration::from_millis(2000));
+
+    //     // Part 1 - insert
+    //     // prints(&goto(0, 0));
+    //     prints("\x1B[4h"); // insert mode
+    //     for i in 0..30 {
+    //         prints(&goto(0, i));
+    //         prints("\x1B[32mabcde\x1B[39m");
+    //         // printf("\x1B[5@\x1B[B"); // ICH (option B)
+    //     }
+    //     prints("\x1B[4l"); // overwrite mode
+    //     // Part 2 - fill left side (option B)
+    //     // for i in 0..30 {
+    //     //     prints(&goto(81, i));
+    //     //     prints("\x1b[32mIJKLM\x1b[39m");
+    //     // }
+    //     flush();
+    //     thread::sleep(Duration::from_millis(2000));
+    // }
+
+
+    // Tab behavior example
+    // {
+    //   printf(&goto(0, 29));
+    //   printf(&"-".repeat(86));
+    //   printf(&goto(0, 0));
+    //   thread::sleep(Duration::from_millis(1000));
+
+    //   printf("123456789a\r\ndefghijklm");
+    //   thread::sleep(Duration::from_millis(2000));
+
+    //   printf(&goto(2, 0));
+    //   thread::sleep(Duration::from_millis(2000));
+
+    //   // printf("\x1B[4h"); // insert mode
+    //   // printf("\n\t0");
+    //   printf("\x1B[6X"); // n to next tapstop (ECH)
+    //   printf("\t0");
+    //   // printf("\x1B[4l"); // overwrite mode
+    //   thread::sleep(Duration::from_millis(2000));
+
+    //   prints(&goto(0, 2));
+    //   prints("qwerqwerxy");
+    //   prints(&goto(0, 3));
+    //   prints("qwerqwerxy");
+    //   thread::sleep(Duration::from_millis(2000));
+
+    //   let rest = ["b", "n", "z", "z"];
+    //   for i in 0..4 {
+    //       prints(&goto(0, i));
+    //       prints("\x1B[P"); // Delete Char (shifts left)
+    //       prints(&goto(8, i));
+    //       prints(rest[i as usize]);
+    //   }
+    //   flush();
+
+    //   // printf("\x1B[5X"); // Erase Char
+
+    //   // printf(&goto(3, 3));
+    //   // thread::sleep(Duration::from_millis(2000));
+
+    //   // printf("\t");
+    //   // thread::sleep(Duration::from_millis(2000));
+    //   // Does not work except on XTerm (vt420 emulation)
+    //   // printf("\x1B[?69h");
+    //   // printf("\x1B[2'~"); // DECIC
+    //   // printf("\x1B[2'}"); // DECDC
+    //   // printf("\x1B[2'~");
+    //   // printf("\x1B[?69l");
+    //   thread::sleep(Duration::from_millis(2000));
+    // }
+
+    let _ = set_mode(&mode);
+    printf(&disable_alt());
+}

--- a/examples/lr_scroll_perf.rs
+++ b/examples/lr_scroll_perf.rs
@@ -88,6 +88,7 @@ fn set_mode(termios: &Termios) -> Result<()> {
     }
 }
 
+#[cfg(unix)]
 fn main() {
     // Null printing test (to see if it skips chars)
     // printf(&"\n".repeat(30));
@@ -239,4 +240,10 @@ fn main() {
 
     let _ = set_mode(&mode);
     printf(&disable_alt());
+}
+
+
+#[cfg(windows)]
+fn main() {
+    println!("Not implemented")
 }

--- a/examples/lr_scroll_perf.rs
+++ b/examples/lr_scroll_perf.rs
@@ -117,9 +117,11 @@ fn main() {
     thread::sleep(Duration::from_millis(1000));
     printf(&goto(80, 0));
     thread::sleep(Duration::from_millis(1000));
+    printf("\x1b[4h");
+    printf("a\ta");
     // printf("whale!Go US");
     // printf("\x1B[2P");
-    // printf("\x1B[4l");
+    printf("\x1B[4l");
     thread::sleep(Duration::from_millis(2000));
 
 

--- a/examples/print_gap.rs
+++ b/examples/print_gap.rs
@@ -113,18 +113,11 @@ fn main() {
     posix::goto(0, 0);
 
     // let string = "👨🏽‍👩🏽‍👧🏽";
-    let climber = "🧗";
-    let skintone = "🏽";
-    let gender = "♀";
-    let string = format!("{}{}\u{200d}{}\u{fe0f}",
-                         climber,
-                         skintone,
-                         gender);
-    let string = string.as_str();
+    let string = &["🧗", "🏽", "\u{200d}", "♀", "\u{fe0f}"].concat();
    
     posix::printf(string);
 
-    thread::sleep(Duration::from_millis(1000));
+    // thread::sleep(Duration::from_millis(1000));
     let (col, row) = pos_raw();
 
     posix::cook(&mode);

--- a/examples/print_gap.rs
+++ b/examples/print_gap.rs
@@ -129,3 +129,8 @@ fn main() {
 
     println!("{}, {}", col, row);
 }
+
+#[cfg(windows)]
+fn main() {
+    println!("Not implemented")
+}

--- a/examples/print_gap.rs
+++ b/examples/print_gap.rs
@@ -1,0 +1,125 @@
+extern crate tuitty;
+
+use std::thread;
+use std::time::Duration;
+#[cfg(not(windows))]
+use std::io::{stdout, BufWriter, Write};
+
+#[cfg(unix)]
+use tuitty::terminal::actions::posix;
+
+// #[cfg(not(windows))]
+// fn prints(content: &str) {
+//     let output = stdout();
+//     let lock = output.lock();
+//     let mut outbuf = BufWriter::new(lock);
+//     outbuf.write_all(content.as_bytes()).expect("I/O error on write");
+// }
+
+// #[cfg(not(windows))]
+// fn flush() {
+//     let output = stdout();
+//     let lock = output.lock();
+//     let mut outbuf = BufWriter::new(lock);
+//     outbuf.flush().expect("I/O error on flush");
+// }
+
+// #[cfg(not(windows))]
+// fn printf(content: &str) {
+//     let output = stdout();
+//     let lock = output.lock();
+//     let mut outbuf = BufWriter::new(lock);
+//     outbuf.write_all(content.as_bytes()).expect("I/O error on write");
+//     outbuf.flush().expect("I/O error on flush");
+// }
+
+#[cfg(not(windows))]
+fn pos_raw() -> (i16, i16) {
+    use std::io::{ Write, BufRead };
+    let ln = 603;
+    // Where is the cursor?
+    // Use `ESC [ 6 n`.
+    let mut stdout = std::io::stdout();
+    let stdin = std::io::stdin();
+
+    // Write command
+    stdout.write_all(b"\x1B[6n").expect(&format!(
+        "buffer.rs [Ln: {}]: Error writing to stdout", ln + 9));
+    stdout.flush().expect(&format!(
+        "buffer.rs [Ln: {}]: Error flushing stdout", ln + 11));
+
+    stdin.lock().read_until(b'[', &mut vec![]).expect(&format!(
+        "buffer.rs [Ln {}]: Error reading stdin", ln + 14));
+
+    let mut rows = vec![];
+    stdin.lock().read_until(b';', &mut rows).expect(&format!(
+        "buffer.rs [Ln {}]: Error reading stdin", ln + 18));
+
+    let mut cols = vec![];
+    stdin.lock().read_until(b'R', &mut cols).expect(&format!(
+        "buffer.rs [Ln {}]: Error reading stdin", ln + 22));
+
+    // remove delimiter
+    rows.pop();
+    cols.pop();
+
+    let rows = rows
+        .into_iter()
+        .map(|b| (b as char))
+        .fold(String::new(), |mut acc, n| {
+            acc.push(n);
+            acc
+        })
+        .parse::<usize>()
+        .expect(&format!(
+            "buffer.rs [Ln {}]: Error parsing row position.", ln + 29
+        ));
+    let cols = cols
+        .into_iter()
+        .map(|b| (b as char))
+        .fold(String::new(), |mut acc, n| {
+            acc.push(n);
+            acc
+        })
+        .parse::<usize>()
+        .expect(&format!(
+            "buffer.rs [Ln {}]: Error parsing col position.", ln + 40
+        ));
+
+    ((cols - 1) as i16, (rows - 1) as i16)
+}
+
+// #[cfg(not(windows))]
+// fn goto(col: i16, row: i16) -> String {
+//     format!("\x1B[{};{}H", row + 1, col + 1)
+// }
+
+// #[cfg(not(windows))]
+// fn enable_alt() -> String {
+//     "\x1B[?1049h".to_string()
+// }
+
+// #[cfg(not(windows))]
+// fn disable_alt() -> String {
+//     "\x1B[?1049l".to_string()
+// }
+
+fn main() {
+    posix::enable_alt();
+    let mode = posix::get_mode();
+    posix::raw();
+
+    posix::goto(0, 0);
+
+    let string = "👨🏽‍👩🏽‍👧🏽";
+    // let string = "🧗🏽‍♀️";
+    posix::printf(string);
+
+    thread::sleep(Duration::from_millis(1000));
+    let (col, row) = pos_raw();
+
+    posix::cook(&mode);
+    posix::disable_alt();
+
+    println!("{}, {}", col, row);
+}

--- a/examples/print_gap.rs
+++ b/examples/print_gap.rs
@@ -33,7 +33,7 @@ use tuitty::terminal::actions::posix;
 //     outbuf.flush().expect("I/O error on flush");
 // }
 
-#[cfg(not(windows))]
+#[cfg(unix)]
 fn pos_raw() -> (i16, i16) {
     use std::io::{ Write, BufRead };
     let ln = 603;
@@ -104,6 +104,7 @@ fn pos_raw() -> (i16, i16) {
 //     "\x1B[?1049l".to_string()
 // }
 
+#[cfg(unix)]
 fn main() {
     posix::enable_alt();
     let mode = posix::get_mode();
@@ -111,8 +112,16 @@ fn main() {
 
     posix::goto(0, 0);
 
-    let string = "👨🏽‍👩🏽‍👧🏽";
-    // let string = "🧗🏽‍♀️";
+    // let string = "👨🏽‍👩🏽‍👧🏽";
+    let climber = "🧗";
+    let skintone = "🏽";
+    let gender = "♀";
+    let string = format!("{}{}\u{200d}{}\u{fe0f}",
+                         climber,
+                         skintone,
+                         gender);
+    let string = string.as_str();
+   
     posix::printf(string);
 
     thread::sleep(Duration::from_millis(1000));

--- a/examples/print_gap.rs
+++ b/examples/print_gap.rs
@@ -114,10 +114,14 @@ fn main() {
 
     // let string = "👨🏽‍👩🏽‍👧🏽";
     let string = &["🧗", "🏽", "\u{200d}", "♀", "\u{fe0f}"].concat();
-   
+    // let string = "👨🏿‍🦰";
+
+    // let string = "👨🏽‍👩🏽‍👧🏽cursor - bad";
+    // let string = &["🧗", "🏽", "\u{200d}", "♀", "\u{fe0f}", "cursor - good"].concat();
+    // let string = "👨🏿‍🦰cursor - good";
     posix::printf(string);
 
-    // thread::sleep(Duration::from_millis(1000));
+    thread::sleep(Duration::from_millis(2000));
     let (col, row) = pos_raw();
 
     posix::cook(&mode);

--- a/examples/set_scroll_perf.rs
+++ b/examples/set_scroll_perf.rs
@@ -1,0 +1,122 @@
+use std::io::{stdout, BufWriter, Write};
+use std::thread;
+use std::time::Duration;
+
+
+fn prints(content: &str) {
+    let output = stdout();
+    let lock = output.lock();
+    let mut outbuf = BufWriter::new(lock);
+    outbuf.write_all(content.as_bytes()).expect("I/O error on write");
+}
+
+fn flush() {
+    let output = stdout();
+    let lock = output.lock();
+    let mut outbuf = BufWriter::new(lock);
+    outbuf.flush().expect("I/O error on flush");
+}
+
+fn printf(content: &str) {
+    let output = stdout();
+    let lock = output.lock();
+    let mut outbuf = BufWriter::new(lock);
+    outbuf.write_all(content.as_bytes()).expect("I/O error on write");
+    outbuf.flush().expect("I/O error on flush");
+}
+
+fn csr(top: usize, bot: usize) -> String {
+    format!("\x1B[{};{}r", top, bot)
+}
+
+fn goto(col: i16, row: i16) -> String {
+    format!("\x1B[{};{}H", row + 1, col + 1)
+}
+
+fn il(n: usize) -> String {
+    format!("\x1B[{}L", n)
+}
+
+fn dl(n: usize) -> String {
+    format!("\x1B[{}M", n)
+}
+
+fn insert(n: usize) {
+    prints(&csr(9, 23));
+    printf(&goto(0, 8));
+
+    thread::sleep(Duration::from_millis(2000));
+
+    prints(&il(n));
+    flush();
+}
+
+fn delete(n: usize) {
+    prints(&csr(9, 23));
+    printf(&goto(0, 8));
+
+    thread::sleep(Duration::from_millis(2000));
+
+    prints(&dl(n));
+    flush();
+
+}
+
+fn scrollup() {
+    insert(1);
+    thread::sleep(Duration::from_millis(2000));
+    printf(&"a".repeat(86));
+}
+
+fn scrolldown() {
+    delete(2);
+    printf(&goto(0, 21));
+    thread::sleep(Duration::from_millis(2000));
+    prints(&"p".repeat(86));
+    printf(&"q".repeat(86));
+    // printf(&"r".repeat(86));
+}
+
+
+fn main() {
+    let (w, h) = (86, 30);
+    let alph = ["b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "r"];
+    let mut idx = 0;
+
+    for i in 0..h {
+        prints(&goto(0, i));
+        if i < 8 || i > 22 {
+            prints(&".".repeat(w));
+        } else {
+            prints(&alph[idx].repeat(w));
+            idx += 1;
+        }
+        flush();
+    }
+
+    // Line feed example:
+    let row = 9;
+    prints(&csr(row, h as usize));
+    printf(&goto(23, 12));
+    thread::sleep(Duration::from_millis(2000));
+    // New Line (LF):
+    // prints(&goto(23, 13));
+    // CRLF:
+    prints(&goto(0, 13));
+    printf(&il(1));
+    thread::sleep(Duration::from_millis(2000));
+
+    // Scroll boundary example: from blessed --
+    // https://github.com/dominictarr/hipster/issues/15
+    // thread::sleep(Duration::from_millis(2000));
+
+    // scrollup();
+    // scrolldown();
+
+    // thread::sleep(Duration::from_millis(2000));
+
+    // Cleanup
+    prints(&csr(0, 30));
+    printf(&goto(85, 29));
+    thread::sleep(Duration::from_millis(2000));
+}

--- a/examples/winbuffer_attrs.rs
+++ b/examples/winbuffer_attrs.rs
@@ -2,7 +2,7 @@
 extern crate tuitty;
 
 #[cfg(windows)]
-use tuitty::common::enums::{Color, foreground, background, effects};
+use tuitty::common::enums::{Color, foreground, background};
 
 #[cfg(windows)]
 extern crate winapi;
@@ -14,87 +14,15 @@ use std::thread;
 #[cfg(windows)]
 use std::time::Duration;
 
-#[cfg(windows)]
-use winapi::um::wincon::{WriteConsoleOutputAttribute,COORD};
-
-#[cfg(windows)]
-use winapi::shared::minwindef::WORD;
-
-pub const RESET: u16 = 0xFFFF;
-pub const IGNORE: u16 = 0xFFF0;
-
-#[cfg(windows)]
-fn get_bg(src: Color) -> WORD {
-    use winapi::um::wincon::{
-        BACKGROUND_RED as RED,
-        BACKGROUND_GREEN as GREEN,
-        BACKGROUND_BLUE as BLUE,
-        BACKGROUND_INTENSITY as INTENSE
-    };
-
-    match src {
-        Color::Black => (0),
-        Color::DarkGrey => (INTENSE),
-        Color::Red => (RED | INTENSE),
-        Color::DarkRed => (GREEN),
-        Color::Green => (GREEN | INTENSE),
-        Color::DarkGreen => (GREEN),
-        Color::Yellow => (RED | GREEN | INTENSE),
-        Color::DarkYellow => (RED | GREEN),
-        Color::Blue => (BLUE | INTENSE),
-        Color::DarkBlue => (BLUE),
-        Color::Magenta => (RED | BLUE | INTENSE),
-        Color::DarkMagenta => (RED | BLUE),
-        Color::Cyan => (GREEN | BLUE | INTENSE),
-        Color::DarkCyan => (GREEN | BLUE),
-        Color::White => (RED | GREEN | BLUE),
-        Color::Grey => (RED | GREEN | BLUE | INTENSE),
-        Color::Reset => (RESET),
-        Color::Rgb{r, g, b} => (IGNORE),
-        Color::AnsiValue(_) => (IGNORE),
-    }
-}
-
-
-#[cfg(windows)]
-fn get_fg(src: Color) -> WORD {
-    use winapi::um::wincon::{
-        FOREGROUND_RED as RED,
-        FOREGROUND_GREEN as GREEN,
-        FOREGROUND_BLUE as BLUE,
-        BACKGROUND_INTENSITY as INTENSE,
-    };
-
-    match src {
-        Color::Black => (0),
-        Color::DarkGrey => (INTENSE),
-        Color::Red => (RED | INTENSE),
-        Color::DarkRed => (GREEN),
-        Color::Green => (GREEN | INTENSE),
-        Color::DarkGreen => (GREEN),
-        Color::Yellow => (RED | GREEN | INTENSE),
-        Color::DarkYellow => (RED | GREEN),
-        Color::Blue => (BLUE | INTENSE),
-        Color::DarkBlue => (BLUE),
-        Color::Magenta => (RED | BLUE | INTENSE),
-        Color::DarkMagenta => (RED | BLUE),
-        Color::Cyan => (GREEN | BLUE | INTENSE),
-        Color::DarkCyan => (GREEN | BLUE),
-        Color::White => (RED | GREEN | BLUE),
-        Color::Grey => (RED | GREEN | BLUE | INTENSE),
-        Color::Reset => (RESET),
-        Color::Rgb{r, g, b} => (IGNORE),
-        Color::AnsiValue(_) => (IGNORE),
-    }
-}
-
-
 
 #[cfg(windows)]
 fn main() {
     let handle = tuitty::terminal::actions::win32::Handle::stdout().unwrap();
     let mode = handle.get_mode().unwrap();
     let info = tuitty::terminal::actions::win32::ConsoleInfo::of(&handle).unwrap();
+
+    let vte = tuitty::terminal::actions::win32::is_ansi_enabled();
+    println!("{}", vte);
 
     let altern = tuitty::terminal::actions::win32::Handle::buffer().unwrap();
     tuitty::terminal::actions::win32::enable_alt(&altern, &mode, false);
@@ -129,7 +57,7 @@ fn main() {
         // thread::sleep(Duration::from_millis(2000));
 
         let default_attr = info.attributes();
-        let mut style_updates: Vec<(WORD, usize, usize)> = vec![];
+        let mut style_updates: Vec<(u16, usize, usize)> = vec![];
 
         // tuitty::terminal::actions::win32::set_fg(Color::Red, default_attr, false);
         // tuitty::terminal::actions::win32::set_bg(Color::Blue, default_attr, false);
@@ -166,58 +94,40 @@ fn main() {
 
         // loop to run through the style updates
         for s in style_updates {
-            let (attr, start, finish) = s;
-            let mut count = 0;
-            let length = finish - start;
-            let col = start as i16 % (size.0 - 1);
-            let row = start as i16 / (size.0 - 1);
-            let styles: Vec<WORD> = vec![attr; length];
+            // let (attr, start, finish) = s;
+            // let mut count = 0;
+            // let length = finish - start;
+            // let col = start as i16 % (size.0 - 1);
+            // let row = start as i16 / (size.0 - 1);
+            // let styles: Vec<WORD> = vec![attr; length];
 
-            let err = unsafe {
-                WriteConsoleOutputAttribute(
-                    altern.0,
-                    styles.as_ptr() as *const WORD,
-                    length as u32,
-                    COORD { X: col, Y: row},
-                    &mut count
-                )
-            };
-            if err == 0 {
-                tuitty::terminal::actions::win32::cook();
-                tuitty::terminal::actions::win32::disable_alt(false);
-                panic!(format!("Something went wrong applying attr to buffer - response: {}", err));
-            }
-            // thread::sleep(Duration::from_millis(2000));
+            // let err = unsafe {
+            //     WriteConsoleOutputAttribute(
+            //         altern.0,
+            //         styles.as_ptr() as *const WORD,
+            //         length as u32,
+            //         COORD { X: col, Y: row},
+            //         &mut count
+            //     )
+            // };
+            // if err == 0 {
+            //     tuitty::terminal::actions::win32::cook();
+            //     tuitty::terminal::actions::win32::disable_alt(false);
+            //     panic!(format!("Something went wrong applying attr to buffer - response: {}", err));
+            // }
+            // // thread::sleep(Duration::from_millis(2000));
+
+            let (word, start, finish) = s;
+            let length = (finish - start) as u32;
+            let coord = (
+                finish as i16 % (size.0 - 1),
+                finish as i16 / (size.0 - 1)
+            );            
+            tuitty::terminal::actions::win32::set_attrib(word, length, coord);
+            thread::sleep(Duration::from_millis(2000));
         }
-        thread::sleep(Duration::from_millis(2000));
+        // thread::sleep(Duration::from_millis(2000));
     }
-
-
-    // unsafe {
-    //     let styles: Vec<WORD> = vec![(FOREGROUND_RED | BACKGROUND_BLUE), FOREGROUND_RED, BACKGROUND_GREEN];
-    //     let count = (size.0 * (size.1 / 3)) as usize;
-
-    //     for (i, w) in styles.iter().enumerate() {
-    //         let attrs: Vec<WORD> = vec![*w; count];
-    //         let row = i as i16 * (size.1 / 3);
-
-    //         let mut attrs_written = 0;
-    //         let res = WriteConsoleOutputAttribute(
-    //             altern.0,
-    //             attrs.as_ptr() as *const WORD,
-    //             count as u32,
-    //             COORD {X: 0, Y: row},
-    //             &mut attrs_written
-    //         );
-    //         if res == 0 {
-    //             tuitty::terminal::actions::win32::cook();
-    //             tuitty::terminal::actions::win32::disable_alt(false);
-    //             panic!(format!("Something went wrong applying attr to buffer - response: {}", res));
-    //         }
-    //         thread::sleep(Duration::from_millis(2000));
-    //     }
-    // };
-
 
     thread::sleep(Duration::from_millis(5000));
 

--- a/examples/winbuffer_attrs.rs
+++ b/examples/winbuffer_attrs.rs
@@ -2,10 +2,7 @@
 extern crate tuitty;
 
 #[cfg(windows)]
-use tuitty::common::unicode::{grapheme::*, wcwidth::*};
-
-#[cfg(windows)]
-use tuitty::common::enums::{Style, Color};
+use tuitty::common::enums::{Color, foreground, background, effects};
 
 #[cfg(windows)]
 extern crate winapi;
@@ -16,113 +13,215 @@ extern crate winapi;
 use std::thread;
 #[cfg(windows)]
 use std::time::Duration;
-#[cfg(windows)]
-use std::ffi::OsStr;
-#[cfg(windows)]
-use std::os::windows::ffi::OsStrExt;
 
 #[cfg(windows)]
-use winapi::um::wincon::{
-    WriteConsoleOutputAttribute,
-    CHAR_INFO, COORD, SMALL_RECT, FOREGROUND_RED, BACKGROUND_BLUE,BACKGROUND_GREEN
-};
+use winapi::um::wincon::{WriteConsoleOutputAttribute,COORD};
 
 #[cfg(windows)]
 use winapi::shared::minwindef::WORD;
+
+pub const RESET: u16 = 0xFFFF;
+pub const IGNORE: u16 = 0xFFF0;
+
+#[cfg(windows)]
+fn get_bg(src: Color) -> WORD {
+    use winapi::um::wincon::{
+        BACKGROUND_RED as RED,
+        BACKGROUND_GREEN as GREEN,
+        BACKGROUND_BLUE as BLUE,
+        BACKGROUND_INTENSITY as INTENSE
+    };
+
+    match src {
+        Color::Black => (0),
+        Color::DarkGrey => (INTENSE),
+        Color::Red => (RED | INTENSE),
+        Color::DarkRed => (GREEN),
+        Color::Green => (GREEN | INTENSE),
+        Color::DarkGreen => (GREEN),
+        Color::Yellow => (RED | GREEN | INTENSE),
+        Color::DarkYellow => (RED | GREEN),
+        Color::Blue => (BLUE | INTENSE),
+        Color::DarkBlue => (BLUE),
+        Color::Magenta => (RED | BLUE | INTENSE),
+        Color::DarkMagenta => (RED | BLUE),
+        Color::Cyan => (GREEN | BLUE | INTENSE),
+        Color::DarkCyan => (GREEN | BLUE),
+        Color::White => (RED | GREEN | BLUE),
+        Color::Grey => (RED | GREEN | BLUE | INTENSE),
+        Color::Reset => (RESET),
+        Color::Rgb{r, g, b} => (IGNORE),
+        Color::AnsiValue(_) => (IGNORE),
+    }
+}
+
+
+#[cfg(windows)]
+fn get_fg(src: Color) -> WORD {
+    use winapi::um::wincon::{
+        FOREGROUND_RED as RED,
+        FOREGROUND_GREEN as GREEN,
+        FOREGROUND_BLUE as BLUE,
+        BACKGROUND_INTENSITY as INTENSE,
+    };
+
+    match src {
+        Color::Black => (0),
+        Color::DarkGrey => (INTENSE),
+        Color::Red => (RED | INTENSE),
+        Color::DarkRed => (GREEN),
+        Color::Green => (GREEN | INTENSE),
+        Color::DarkGreen => (GREEN),
+        Color::Yellow => (RED | GREEN | INTENSE),
+        Color::DarkYellow => (RED | GREEN),
+        Color::Blue => (BLUE | INTENSE),
+        Color::DarkBlue => (BLUE),
+        Color::Magenta => (RED | BLUE | INTENSE),
+        Color::DarkMagenta => (RED | BLUE),
+        Color::Cyan => (GREEN | BLUE | INTENSE),
+        Color::DarkCyan => (GREEN | BLUE),
+        Color::White => (RED | GREEN | BLUE),
+        Color::Grey => (RED | GREEN | BLUE | INTENSE),
+        Color::Reset => (RESET),
+        Color::Rgb{r, g, b} => (IGNORE),
+        Color::AnsiValue(_) => (IGNORE),
+    }
+}
+
+
 
 #[cfg(windows)]
 fn main() {
     let handle = tuitty::terminal::actions::win32::Handle::stdout().unwrap();
     let mode = handle.get_mode().unwrap();
     let info = tuitty::terminal::actions::win32::ConsoleInfo::of(&handle).unwrap();
-    let attrs = info.attributes();
 
     let altern = tuitty::terminal::actions::win32::Handle::buffer().unwrap();
     tuitty::terminal::actions::win32::enable_alt(&altern, &mode, false);
 
-    let _ = tuitty::terminal::actions::win32::set_fg(Color::Red, attrs, false);
-
-    let attrs_mod = info.attributes();
-
-    let _ = tuitty::terminal::actions::win32::reset_styles(attrs, false);
-
-
-
-    let example_output = "qwertyuiopasd⚠️fghjkl😀園v明nmQWE👪RTY👨‍👩‍👧UIOPASDFGHJKLZXCVBNM";
-
+    // let _ = tuitty::terminal::actions::win32::set_fg(Color::Red, attrs, false);
+    // let attrs_mod = info.attributes();
+    // let _ = tuitty::terminal::actions::win32::reset_styles(attrs, false);
+    // let example_output = "qwertyuiopasd⚠️fghjkl😀園v明nmQWE👪RTY👨‍👩‍👧UIOPASDFGHJKLZXCVBNM";
     tuitty::terminal::actions::win32::goto(0, 0, false);
     // tuitty::terminal::actions::win32::printf(example_output, false);
-    // Size within sub-terminal (eg. windows terminal or cmder) is incorrect...
     let size = info.terminal_size();
-    println!("X: {}, Y: {}", size.0, size.1);
+    // println!("X: {}, Y: {}", size.0, size.1);
     let size = (size.0 + 1, size.1 + 1);
 
-    let mut screen_str = String::new();
-    let alpha = ["a","b","c","d","e","f","g","h","i","j","k","l","m","n","o","p","q","r","s","t","u","v","w","x","y","z","0","1","2","3","4","5","6","7","8","9","0"];
-    for i in 0..size.1 {
-        screen_str.push_str(&format!("{}", alpha[i as usize]).repeat(size.0 as usize));
-    }
-    tuitty::terminal::actions::win32::printf(&screen_str, false);
-
-    thread::sleep(Duration::from_millis(2000));
-
-    let mut innerbuf: Vec<Option<Vec<u16>>> = vec![None; (size.0 * size.1) as usize];
-
-    let first_row = 0;
-    let first_col = size.0 as usize;
-    for i in first_row..first_col {
-        innerbuf[i] = Some(vec!['a' as u16]);
-    }
-
-    let last_row = (size.0 * (size.1 - 1)) as usize;
-    let last_col = last_row + size.0 as usize;
-    for i in last_row..last_col {
-        innerbuf[i] = Some(vec!['z' as u16]);
-    }
-
-    let index = size.0 as usize / 2;
-    innerbuf[index] = Some(OsStr::new("👪").encode_wide().collect());
-    innerbuf[index + 1] = Some(vec![]);
-
-    let mut output: Vec<u16> = vec![];
-    for v in &innerbuf {
-        match v {
-            Some(u) => { for i in u { output.push(*i) }},
-            None => output.push('-' as u16),
+    for i in 0..2 {
+        let mut screen_str = String::new();
+        let mut alpha = ["a","b","c","d","e","f","g","h","i","j","k","l","m","n","o","p","q","r","s","t","u","v","w","x","y","z","0","1","2","3","4","5","6","7","8","9","0"];
+        if i > 0 {
+            alpha.reverse();
         }
+        for i in 0..size.1 {
+            screen_str.push_str(&format!("{}", alpha[i as usize]).repeat(size.0 as usize));
+        }
+        tuitty::terminal::actions::win32::printf(&screen_str, false);
+
+        // thread::sleep(Duration::from_millis(2000));
+
+        tuitty::terminal::actions::win32::goto(0, 12, false);
+        let emoji_string = "👪".repeat(size.0 as usize / 2);
+        tuitty::terminal::actions::win32::printf(&emoji_string, false);
+
+        // thread::sleep(Duration::from_millis(2000));
+
+        let default_attr = info.attributes();
+        let mut style_updates: Vec<(WORD, usize, usize)> = vec![];
+
+        // tuitty::terminal::actions::win32::set_fg(Color::Red, default_attr, false);
+        // tuitty::terminal::actions::win32::set_bg(Color::Blue, default_attr, false);
+        let mut current = default_attr;
+        current = foreground(Color::Red, current, default_attr);
+        current = background(Color::Blue, current, default_attr);
+        let start: usize;
+        let finish: usize;
+        if i > 0 {
+            start = 96;
+            finish = 85 * 2 + 46;
+        } else {
+            start = 33;
+            finish = 85 * 2 + 18;
+        }
+        style_updates.push((current, start, finish));
+        tuitty::terminal::actions::win32::reset_styles(default_attr, false);
+        current = default_attr;
+
+        tuitty::terminal::actions::win32::set_bg(Color::Green, default_attr, false);
+        current = background(Color::Green, current, default_attr);
+        let start: usize;
+        let finish: usize;
+        if i > 0 {
+            start = 85 * 9;
+            finish = 85 * 12;
+        } else {
+            start = 85 * 4 + 2;
+            finish = 85 * 6 + 8;
+        }
+        style_updates.push((current, start, finish));
+        tuitty::terminal::actions::win32::reset_styles(default_attr, false);
+        // current = default_attr;
+
+        // loop to run through the style updates
+        for s in style_updates {
+            let (attr, start, finish) = s;
+            let mut count = 0;
+            let length = finish - start;
+            let col = start as i16 % (size.0 - 1);
+            let row = start as i16 / (size.0 - 1);
+            let styles: Vec<WORD> = vec![attr; length];
+
+            let err = unsafe {
+                WriteConsoleOutputAttribute(
+                    altern.0,
+                    styles.as_ptr() as *const WORD,
+                    length as u32,
+                    COORD { X: col, Y: row},
+                    &mut count
+                )
+            };
+            if err == 0 {
+                tuitty::terminal::actions::win32::cook();
+                tuitty::terminal::actions::win32::disable_alt(false);
+                panic!(format!("Something went wrong applying attr to buffer - response: {}", err));
+            }
+            // thread::sleep(Duration::from_millis(2000));
+        }
+        thread::sleep(Duration::from_millis(2000));
     }
 
-    tuitty::terminal::actions::win32::goto(0, 0, false);
-    let str_output = String::from_utf16(&output).unwrap();
-    tuitty::terminal::actions::win32::printf(&str_output, false);
 
-    // thread::sleep(Duration::from_millis(2000));
+    // unsafe {
+    //     let styles: Vec<WORD> = vec![(FOREGROUND_RED | BACKGROUND_BLUE), FOREGROUND_RED, BACKGROUND_GREEN];
+    //     let count = (size.0 * (size.1 / 3)) as usize;
 
-    let mut attr_cnt = 0;
-    let attr_res = unsafe {
-        // let mut attrss: [WORD; 2] = [0, 0];
-        // attrss[0] = FOREGROUND_RED | BACKGROUND_BLUE;
-        // attrss[1] = BACKGROUND_BLUE | FOREGROUND_RED;
-        let attrss = vec![(0x0020 as WORD | 0x0004 as WORD), attrs, (0x0020 as WORD | 0x0004 as WORD)];
-        WriteConsoleOutputAttribute(
-            altern.0,
-            attrss.as_ptr() as *const WORD,
-            // &(BACKGROUND_GREEN | FOREGROUND_RED),
-            3,
-            COORD {X: 2, Y: 3},
-            &mut attr_cnt
-        )
-    };
+    //     for (i, w) in styles.iter().enumerate() {
+    //         let attrs: Vec<WORD> = vec![*w; count];
+    //         let row = i as i16 * (size.1 / 3);
 
-    if attr_res == 0 {
-        tuitty::terminal::actions::win32::cook();
-        tuitty::terminal::actions::win32::disable_alt(false);
-        panic!(format!("Something went wrong applying attr to buffer - response: {}", attr_res));
-    }
+    //         let mut attrs_written = 0;
+    //         let res = WriteConsoleOutputAttribute(
+    //             altern.0,
+    //             attrs.as_ptr() as *const WORD,
+    //             count as u32,
+    //             COORD {X: 0, Y: row},
+    //             &mut attrs_written
+    //         );
+    //         if res == 0 {
+    //             tuitty::terminal::actions::win32::cook();
+    //             tuitty::terminal::actions::win32::disable_alt(false);
+    //             panic!(format!("Something went wrong applying attr to buffer - response: {}", res));
+    //         }
+    //         thread::sleep(Duration::from_millis(2000));
+    //     }
+    // };
 
 
     thread::sleep(Duration::from_millis(5000));
 
+    
     tuitty::terminal::actions::win32::cook();
     tuitty::terminal::actions::win32::disable_alt(false);
 }

--- a/examples/winbuffer_attrs.rs
+++ b/examples/winbuffer_attrs.rs
@@ -1,0 +1,128 @@
+#[cfg(windows)]
+extern crate tuitty;
+
+#[cfg(windows)]
+use tuitty::common::unicode::{grapheme::*, wcwidth::*};
+
+#[cfg(windows)]
+use tuitty::common::enums::{Style, Color};
+
+#[cfg(windows)]
+extern crate winapi;
+
+// #[cfg(windows)]
+// use std::mem::zeroed;
+#[cfg(windows)]
+use std::thread;
+#[cfg(windows)]
+use std::time::Duration;
+#[cfg(windows)]
+use std::ffi::OsStr;
+#[cfg(windows)]
+use std::os::windows::ffi::OsStrExt;
+
+#[cfg(windows)]
+use winapi::um::wincon::{
+    WriteConsoleOutputAttribute,
+    CHAR_INFO, COORD, SMALL_RECT, FOREGROUND_RED, BACKGROUND_BLUE,BACKGROUND_GREEN
+};
+
+#[cfg(windows)]
+use winapi::shared::minwindef::WORD;
+
+#[cfg(windows)]
+fn main() {
+    let handle = tuitty::terminal::actions::win32::Handle::stdout().unwrap();
+    let mode = handle.get_mode().unwrap();
+    let info = tuitty::terminal::actions::win32::ConsoleInfo::of(&handle).unwrap();
+    let attrs = info.attributes();
+
+    let altern = tuitty::terminal::actions::win32::Handle::buffer().unwrap();
+    tuitty::terminal::actions::win32::enable_alt(&altern, &mode, false);
+
+    let _ = tuitty::terminal::actions::win32::set_fg(Color::Red, attrs, false);
+
+    let attrs_mod = info.attributes();
+
+    let _ = tuitty::terminal::actions::win32::reset_styles(attrs, false);
+
+
+
+    let example_output = "qwertyuiopasd⚠️fghjkl😀園v明nmQWE👪RTY👨‍👩‍👧UIOPASDFGHJKLZXCVBNM";
+
+    tuitty::terminal::actions::win32::goto(0, 0, false);
+    // tuitty::terminal::actions::win32::printf(example_output, false);
+    // Size within sub-terminal (eg. windows terminal or cmder) is incorrect...
+    let size = info.terminal_size();
+    println!("X: {}, Y: {}", size.0, size.1);
+    let size = (size.0 + 1, size.1 + 1);
+
+    let mut screen_str = String::new();
+    let alpha = ["a","b","c","d","e","f","g","h","i","j","k","l","m","n","o","p","q","r","s","t","u","v","w","x","y","z","0","1","2","3","4","5","6","7","8","9","0"];
+    for i in 0..size.1 {
+        screen_str.push_str(&format!("{}", alpha[i as usize]).repeat(size.0 as usize));
+    }
+    tuitty::terminal::actions::win32::printf(&screen_str, false);
+
+    thread::sleep(Duration::from_millis(2000));
+
+    let mut innerbuf: Vec<Option<Vec<u16>>> = vec![None; (size.0 * size.1) as usize];
+
+    let first_row = 0;
+    let first_col = size.0 as usize;
+    for i in first_row..first_col {
+        innerbuf[i] = Some(vec!['a' as u16]);
+    }
+
+    let last_row = (size.0 * (size.1 - 1)) as usize;
+    let last_col = last_row + size.0 as usize;
+    for i in last_row..last_col {
+        innerbuf[i] = Some(vec!['z' as u16]);
+    }
+
+    let index = size.0 as usize / 2;
+    innerbuf[index] = Some(OsStr::new("👪").encode_wide().collect());
+    innerbuf[index + 1] = Some(vec![]);
+
+    let mut output: Vec<u16> = vec![];
+    for v in &innerbuf {
+        match v {
+            Some(u) => { for i in u { output.push(*i) }},
+            None => output.push('-' as u16),
+        }
+    }
+
+    tuitty::terminal::actions::win32::goto(0, 0, false);
+    let str_output = String::from_utf16(&output).unwrap();
+    tuitty::terminal::actions::win32::printf(&str_output, false);
+
+    // thread::sleep(Duration::from_millis(2000));
+
+    let mut attr_cnt = 0;
+    let attr_res = unsafe {
+        // let mut attrss: [WORD; 2] = [0, 0];
+        // attrss[0] = FOREGROUND_RED | BACKGROUND_BLUE;
+        // attrss[1] = BACKGROUND_BLUE | FOREGROUND_RED;
+        let attrss = vec![(0x0020 as WORD | 0x0004 as WORD), attrs, (0x0020 as WORD | 0x0004 as WORD)];
+        WriteConsoleOutputAttribute(
+            altern.0,
+            attrss.as_ptr() as *const WORD,
+            // &(BACKGROUND_GREEN | FOREGROUND_RED),
+            3,
+            COORD {X: 2, Y: 3},
+            &mut attr_cnt
+        )
+    };
+
+    if attr_res == 0 {
+        tuitty::terminal::actions::win32::cook();
+        tuitty::terminal::actions::win32::disable_alt(false);
+        panic!(format!("Something went wrong applying attr to buffer - response: {}", attr_res));
+    }
+
+
+    thread::sleep(Duration::from_millis(5000));
+
+    tuitty::terminal::actions::win32::cook();
+    tuitty::terminal::actions::win32::disable_alt(false);
+}

--- a/examples/winbuffer_write.rs
+++ b/examples/winbuffer_write.rs
@@ -1,0 +1,343 @@
+#[cfg(windows)]
+extern crate tuitty;
+
+#[cfg(windows)]
+use tuitty::common::unicode::{grapheme::*, wcwidth::*};
+
+#[cfg(windows)]
+extern crate winapi;
+
+// #[cfg(windows)]
+// use std::mem::zeroed;
+#[cfg(windows)]
+use std::thread;
+#[cfg(windows)]
+use std::time::Duration;
+#[cfg(windows)]
+use std::ffi::OsStr;
+#[cfg(windows)]
+use std::os::windows::ffi::OsStrExt;
+
+// #[cfg(windows)]
+// use winapi::um::wincon::{
+//     WriteConsoleOutputW,
+//     CHAR_INFO, COORD, SMALL_RECT
+// };
+#[cfg(windows)]
+use winapi::um::consoleapi::WriteConsoleW;
+#[cfg(windows)]
+use winapi::shared::ntdef::{ NULL, VOID };
+
+
+#[cfg(windows)]
+fn main() {
+    let handle = tuitty::terminal::actions::win32::Handle::stdout().unwrap();
+    let mode = handle.get_mode().unwrap();
+    let info = tuitty::terminal::actions::win32::ConsoleInfo::of(&handle).unwrap();
+    let attrs = info.attributes();
+
+    let altern = tuitty::terminal::actions::win32::Handle::buffer().unwrap();
+    tuitty::terminal::actions::win32::enable_alt(&altern, &mode, false);
+
+    let example_output = "qwertyuiopasd⚠️fghjkl😀園v明nmQWE👪RTY👨‍👩‍👧UIOPASDFGHJKLZXCVBNM";
+
+    tuitty::terminal::actions::win32::goto(0, 0, false);
+    // tuitty::terminal::actions::win32::printf(example_output, false);
+    // Size within sub-terminal (eg. windows terminal or cmder) is incorrect...
+    let size = info.terminal_size();
+    println!("X: {}, Y: {}", size.0, size.1);
+    let size = (size.0 + 1, size.1 + 1);
+
+    let mut screen_str = String::new();
+    let alpha = ["a","b","c","d","e","f","g","h","i","j","k","l","m","n","o","p","q","r","s","t","u","v","w","x","y","z","0","1","2","3","4","5","6","7","8","9","0"];
+    for i in 0..size.1 {
+        screen_str.push_str(&format!("{}", alpha[i as usize]).repeat(size.0 as usize));
+    }
+    tuitty::terminal::actions::win32::printf(&screen_str, false);
+
+    thread::sleep(Duration::from_millis(2000));
+
+    // let size = (85, 29);
+
+    // let buf_size = COORD {X: size.0 , Y: size.1};
+    // let buf_coord = COORD {X: 0, Y: 0};
+    // let mut dest_rect = SMALL_RECT {
+    //     Top: 0,
+    //     Left: 0,
+    //     Bottom: size.1,
+    //     Right: size.0,
+    // };
+
+    // let mut winbuf: Vec<CHAR_INFO> = unsafe {
+    //     let mut defch: CHAR_INFO = zeroed();
+    //     defch.Attributes = attrs;
+    //     vec![defch; (size.0 * size.1) as usize * 4]
+    // };
+
+    let mut innerbuf: Vec<Option<Vec<u16>>> = vec![None; (size.0 * size.1) as usize];
+
+    let first_row = 0;
+    let first_col = size.0 as usize;
+    for i in first_row..first_col {
+        innerbuf[i] = Some(vec!['a' as u16]);
+    }
+
+    let last_row = (size.0 * (size.1 - 1)) as usize;
+    let last_col = last_row + size.0 as usize;
+    for i in last_row..last_col {
+        innerbuf[i] = Some(vec!['z' as u16]);
+    }
+
+    let index = size.0 as usize / 2;
+    innerbuf[index] = Some(OsStr::new("👪").encode_wide().collect());
+    innerbuf[index + 1] = Some(vec![]);
+
+    let mut output: Vec<u16> = vec![];
+    for v in &innerbuf {
+        match v {
+            Some(u) => { for i in u { output.push(*i) }},
+            None => output.push('-' as u16),
+        }
+    }
+
+    tuitty::terminal::actions::win32::goto(0, 0, false);
+    let str_output = String::from_utf16(&output).unwrap();
+    tuitty::terminal::actions::win32::printf(&str_output, false);
+
+    thread::sleep(Duration::from_millis(2000));
+
+    tuitty::terminal::actions::win32::goto(0, 0, false);
+    tuitty::terminal::actions::win32::printf(&format!("{}", "🔣".width()), false);
+    tuitty::terminal::actions::win32::printf("🔣", false);
+
+    thread::sleep(Duration::from_millis(2000));
+
+    let mut innerbuf: Vec<Option<Vec<u16>>> = vec![None; (size.0 * size.1) as usize];
+    
+    // let original: Vec<u16> = OsStr::new(example_output).encode_wide().collect();
+    // let mut index = 0;
+    // for ch in original {
+    //     unsafe { *winbuf[index].Char.UnicodeChar_mut() = ch }
+    //     index += 1;
+    // }
+    let example_output = "qwertyuiopasd⚠️fghjkl😀園v明nmQWE👪RTY👨‍👩‍👧UIOPASDFGHJKLZXCVBNM";
+
+
+    let segments: Vec<&str> = UnicodeGraphemes::graphemes(example_output, true).collect();
+    let mut index = 0;
+    for s in segments {
+        match s.width() {
+            1 => {
+                if s.contains("\u{fe0f}") {
+                    innerbuf[index] = Some(OsStr::new(s).encode_wide().collect());
+                    innerbuf[index  + 1] = Some(vec![]);
+                    index += 2;
+                } else {
+                    innerbuf[index] = Some(OsStr::new(s).encode_wide().collect());
+                    index += 1;
+                }
+            },
+            2 => {
+                innerbuf[index] = Some(OsStr::new(s).encode_wide().collect());
+                innerbuf[index  + 1] = Some(vec![]);
+                index += 2;
+            },
+            _ => {
+                innerbuf[index] = Some(OsStr::new("🔣").encode_wide().collect());
+                innerbuf[index  + 1] = Some(vec![]);
+                index += 2;
+            }
+        }
+    }
+
+    // let patch: Vec<u16> = OsStr::new("👪").encode_wide().collect();
+    // let row = 9 * size.0;
+    // let col = 12;
+    // let mut index = (row + col) as usize;
+    // for ch in patch {
+    //     unsafe { *winbuf[index].Char.UnicodeChar_mut() = ch }
+    //     index += 1;
+    // }
+    let patch: Vec<&str> = UnicodeGraphemes::graphemes("👪", true).collect();
+    let row = 9 * size.0; // 10th row
+    let col = 0;
+    let mut index = (row + col) as usize;
+    // let mut index = 0;
+    for s in patch {
+        match s.width() {
+            1 => {
+                if s.contains("\u{fe0f}") {
+                    innerbuf[index] = Some(OsStr::new(s).encode_wide().collect());
+                    innerbuf[index  + 1] = Some(vec![]);
+                    index += 2;
+                } else {
+                    innerbuf[index] = Some(OsStr::new(s).encode_wide().collect());
+                    index += 1;
+                }
+            },
+            2 => {
+                innerbuf[index] = Some(OsStr::new(s).encode_wide().collect());
+                innerbuf[index  + 1] = Some(vec![]);
+                index += 2;
+            },
+            _ => {
+                innerbuf[index] = Some(OsStr::new("🔣").encode_wide().collect());
+                innerbuf[index  + 1] = Some(vec![]);
+                index += 2;
+            }
+        }
+    }
+
+    // let patch2: Vec<u16> = OsStr::new("--").encode_wide().collect();
+    // let row = 9 * size.0;
+    // let col = 15;
+    // let mut index = (row + col) as usize;
+    // for ch in patch2 {
+    //     unsafe { *winbuf[index].Char.UnicodeChar_mut() = ch }
+    //     index += 1;
+    // }
+    let patch: Vec<&str> = UnicodeGraphemes::graphemes("xx", true).collect();
+    let row = 9 * size.0;
+    let col = 3;
+    let mut index = (row + col) as usize;
+    for s in patch {
+        match s.width() {
+            1 => {
+                if s.contains("\u{fe0f}") {
+                    innerbuf[index] = Some(OsStr::new(s).encode_wide().collect());
+                    innerbuf[index  + 1] = Some(vec![]);
+                    index += 2;
+                } else {
+                    innerbuf[index] = Some(OsStr::new(s).encode_wide().collect());
+                    index += 1;
+                }
+            },
+            2 => {
+                innerbuf[index] = Some(OsStr::new(s).encode_wide().collect());
+                innerbuf[index  + 1] = Some(vec![]);
+                index += 2;
+            },
+            _ => {
+                innerbuf[index] = Some(OsStr::new("🔣").encode_wide().collect());
+                innerbuf[index  + 1] = Some(vec![]);
+                index += 2;
+            }
+        }
+    }
+
+    // let copy: Vec<u16> = OsStr::new(example_output).encode_wide().collect();
+    // let mut index = 85 + 41;
+    // for ch in copy {
+    //     unsafe { *winbuf[index].Char.UnicodeChar_mut() = ch }
+    //     index += 1;
+    // }
+    let copy: Vec<&str> = UnicodeGraphemes::graphemes(example_output, true).collect();
+    let mut index = (size.0 as usize * 1) + 20; // second row
+    for s in copy {
+        match s.width() {
+            1 => {
+                if s.contains("\u{fe0f}") {
+                    innerbuf[index] = Some(OsStr::new(s).encode_wide().collect());
+                    innerbuf[index  + 1] = Some(vec![]);
+                    index += 2;
+                } else {
+                    innerbuf[index] = Some(OsStr::new(s).encode_wide().collect());
+                    index += 1;
+                }
+            },
+            2 => {
+                innerbuf[index] = Some(OsStr::new(s).encode_wide().collect());
+                innerbuf[index  + 1] = Some(vec![]);
+                index += 2;
+            },
+            _ => {
+                innerbuf[index] = Some(OsStr::new("🔣").encode_wide().collect());
+                innerbuf[index  + 1] = Some(vec![]);
+                index += 2;
+            }
+        }
+    }
+
+    // let mut index = 0;
+    // for c in &innerbuf {
+    //     match c {
+    //         Some(s) => for ch in s {
+    //             unsafe { *winbuf[index].Char.UnicodeChar_mut() = *ch }
+    //             index += 1;
+    //         },
+    //         None => {
+    //             unsafe { *winbuf[index].Char.UnicodeChar_mut() = ' ' as u16 }
+    //             index += 1;
+    //         }
+    //     }
+    // }
+
+    // tuitty::terminal::actions::win32::goto(0, 0, false);
+    // tuitty::terminal::actions::win32::printf(example_output, false);
+
+    // //let index = (size.0 as usize * 5);
+    // let index = (size.0 as usize) * 2;
+    // let h: Vec<u16> = OsStr::new("h").encode_wide().collect();
+    // innerbuf[index] = Some(h);
+    // let e: Vec<u16> = OsStr::new("e").encode_wide().collect();
+    // innerbuf[index + 4] = Some(e);
+
+
+    // let write_err = unsafe {
+    //     WriteConsoleOutputW(
+    //         altern.0,
+    //         winbuf.as_ptr(), 
+    //         COORD {X: size.0, Y: size.1},
+    //         COORD {X: 0, Y: 0},
+    //         &mut SMALL_RECT {
+    //             Top: 0,
+    //             Left: 0,
+    //             Bottom: size.1,
+    //             Right: size.0,
+    //         })
+    // };
+
+    
+
+    // use winapi::um::consoleapi::WriteConsoleW;
+    // use winapi::shared::ntdef::{ NULL, VOID };
+
+    let mut output: Vec<u16> = vec![];
+    for v in &innerbuf {
+        match v {
+            Some(u) => { for i in u { output.push(*i) }},
+            None => output.push(' ' as u16),
+        }
+    }
+
+    tuitty::terminal::actions::win32::goto(0, 0, false);
+
+    // let mut written_chars = 0;
+    // let write_err = unsafe {
+    //     WriteConsoleW(
+    //         altern.0,
+    //         output.as_ptr() as *const VOID,
+    //         (size.0 * size.1) as u32,
+    //         &mut written_chars, NULL
+    //     )
+    // };
+
+    // if write_err == 0 {
+    //     tuitty::terminal::actions::win32::cook();
+    //     tuitty::terminal::actions::win32::disable_alt(false);
+    //     panic!("Something went wrong copying buffer");
+    // }
+
+    let str_output = String::from_utf16(&output).unwrap();
+    tuitty::terminal::actions::win32::printf(&str_output, false);
+
+    thread::sleep(Duration::from_millis(2000));
+
+    // tuitty::terminal::actions::win32::printf("!", false);
+    tuitty::terminal::actions::win32::goto(size.0 - 1, size.1 - 1, false);
+
+    thread::sleep(Duration::from_millis(5000));
+
+    tuitty::terminal::actions::win32::cook();
+    tuitty::terminal::actions::win32::disable_alt(false);
+}

--- a/examples/winbuffer_write.rs
+++ b/examples/winbuffer_write.rs
@@ -333,8 +333,8 @@ fn main() {
 
     thread::sleep(Duration::from_millis(2000));
 
-    // tuitty::terminal::actions::win32::printf("!", false);
     tuitty::terminal::actions::win32::goto(size.0 - 1, size.1 - 1, false);
+    tuitty::terminal::actions::win32::printf(" ", false);
 
     thread::sleep(Duration::from_millis(5000));
 

--- a/examples/windows_write.rs
+++ b/examples/windows_write.rs
@@ -1,0 +1,337 @@
+extern crate tuitty;
+extern crate winapi;
+
+use winapi::um::wincon::{
+    WriteConsoleOutputW,
+    WriteConsoleOutputA,
+    ReadConsoleOutputW,
+    ReadConsoleOutputA,
+    CHAR_INFO, COORD, SMALL_RECT
+};
+use std::mem::zeroed;
+use std::thread;
+use std::time::Duration;
+use std::ffi::OsStr;
+use std::os::windows::ffi::OsStrExt;
+use std::ptr::null_mut;
+
+
+use winapi::um::consoleapi::{
+    ReadConsoleW, WriteConsoleW
+};
+
+use winapi::ctypes::c_void;
+
+fn main() {
+    let handle = tuitty::terminal::actions::win32::Handle::stdout().unwrap();
+    let mode = handle.get_mode().unwrap();
+    let info = tuitty::terminal::actions::win32::ConsoleInfo::of(&handle).unwrap();
+    let attrs = info.attributes();
+
+    // let blue = 0x0001;
+    // let green = 0x0002;
+    // let red = 0x0004;
+    
+
+    let altern = tuitty::terminal::actions::win32::Handle::buffer().unwrap();
+    tuitty::terminal::actions::win32::enable_alt(&altern, &mode, false);
+    // tuitty::terminal::actions::win32::raw();
+
+
+    // let output = "qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM";
+    // let differ = "qwertyuiopasdfghjkl園xcvbnmQWERTYUIOPASDFGHJKLZXCVBNM";
+    let output = "qwertyuiopasd⚠️fghjkl😀園v明nmQWE👪RTY👨‍👩‍👧UIOPASDFGHJKLZXCVBNM";
+    // let d16 = differ.encode_utf16();
+    // let o16 = output.encode_utf16();
+
+
+    // visualize difference:
+    // let mut index = 0;
+    // for (o, d) in o16.zip(d16) {
+    //     if o != d {
+    //         println!("not equal @ i: {}", index);
+    //         println!("o: {}", o);
+    //         println!("d: {}", d);
+    //         println!("-----")
+    //     }
+    //     index += 1;
+    // }
+
+
+    // Write to buffer
+    tuitty::terminal::actions::win32::goto(0, 0, false);
+    tuitty::terminal::actions::win32::printf(output, false);
+
+    // tuitty::terminal::actions::win32::goto(0, 20, false);
+    // tuitty::terminal::actions::win32::printf(output, false);
+    thread::sleep(Duration::from_millis(2000));
+
+    // tuitty::terminal::actions::win32::goto(13, 0, false);
+    // let mut ret = String::new();
+    // let data: *mut std::ffi::c_void = ret.as_mut_ptr();
+    // let read_ch = unsafe {
+    //     ReadConsoleW(altern.0, lpBuffer: LPVOID, nNumberOfCharsToRead: DWORD, lpNumberOfCharsRead: LPDWORD, pInputControl: PCONSOLE_READCONSOLE_CONTROL)
+    // }
+
+    // // Setup ranges
+
+    // // this is essentially taken from read_buf -- 
+    // let _char_info_buf = o16
+    //     .map(|ch| unsafe {
+    //         let mut char_info: CHAR_INFO = zeroed();
+    //         char_info.Attributes = attrs;
+    //         *char_info.Char.UnicodeChar_mut() = ch;
+    //         char_info
+    //     }).collect::<Vec<CHAR_INFO>>();
+    
+    // let len = char_info_buf.len();
+    // let len = 85 * 29;
+    let size = info.terminal_size();
+    println!("X: {}, Y: {}", size.0, size.1);
+    let buf_sizze = COORD {X: 85 , Y: 29};
+    let buf_coord = COORD {X: 0, Y: 0};
+    let mut dest_rect = SMALL_RECT {
+        Top: 0,
+        Left: 0,
+        Bottom: 29,
+        Right: 85,
+    };
+
+    // Read contents
+    // let mut read_buf: Vec<CHAR_INFO> = Vec::with_capacity(len);
+    let mut read_buf: Vec<CHAR_INFO> = unsafe { vec![zeroed(); 85 * 29 * 4] };
+    // let mut read_buf = unsafe { vec![zeroed(); 85 * 29 * 4] };
+    let buf_read = unsafe {
+        ReadConsoleOutputW(
+        // ReadConsoleOutputA(
+            altern.0, 
+            read_buf.as_mut_ptr(), 
+            buf_sizze, 
+            buf_coord,
+            &mut dest_rect)
+        };
+    if buf_read == 0 { 
+        tuitty::terminal::actions::win32::cook();
+        tuitty::terminal::actions::win32::disable_alt(false);
+        panic!("Something went wrong reading buffer");
+    }
+
+    let read_u16: Vec<u16> = read_buf.iter().map(|x| unsafe { *x.Char.UnicodeChar() }).collect();
+    let read_string: String = String::from_utf16_lossy(&read_u16);
+    tuitty::terminal::actions::win32::goto(0, 0, false);
+    let mut written = 0;
+    let res = unsafe {
+        WriteConsoleW(
+            altern.0,
+            read_string.as_ptr() as *const c_void,
+            85 * 29,
+            &mut written, null_mut()
+        )
+    };
+    if res == 0 {
+            tuitty::terminal::actions::win32::cook();
+            tuitty::terminal::actions::win32::disable_alt(false);
+            panic!("Something went wrong pasting buffer");
+    }
+    
+
+
+    // let mut index = 0;
+    // for u in OsStr::new(&read_string).encode_wide() {
+    //     unsafe {
+    //         *read_buf[index].Char.UnicodeChar_mut() = u;    
+    //     }
+    //     index += 1;
+    // };
+
+    // // Copy contents over
+    // let buf_copy = unsafe {
+    //     WriteConsoleOutputW(
+    //     // WriteConsoleOutputA(
+    //         altern.0, 
+    //         read_buf.as_ptr(), 
+    //         // COORD {X: len as i16, Y: 1},
+    //         COORD {X: 51, Y: 1},
+    //         COORD {X: 0, Y: 0},
+    //         &mut SMALL_RECT {
+    //             Top: 5,
+    //             Left: 5,
+    //             Bottom: 29,
+    //             Right: 85,
+    //         })
+    // };
+
+    // if buf_copy == 0 { 
+    //     tuitty::terminal::actions::win32::cook();
+    //     tuitty::terminal::actions::win32::disable_alt(false);
+    //     panic!("Something went wrong copying buffer");
+    // }
+
+    thread::sleep(Duration::from_millis(2000));
+
+
+    // // Check read_buf contents
+    // // when read_buf was Vec::with_capacity();
+    // tuitty::terminal::actions::win32::goto(0, 8, false);
+    // // Check dest_rect
+    // tuitty::terminal::actions::win32::printf(
+    //     &format!("top: {}, left: {}, bot: {}, right: {}",
+    //     dest_rect.Top, dest_rect.Left, dest_rect.Bottom, dest_rect.Right
+    // ), false);
+    // // Check Char
+    // // let mut chinfo = *read_buf.get(0).unwrap();
+    // let buf = unsafe {
+    //     // when read_buf was Vec::with_capacity();
+    //     std::slice::from_raw_parts(read_buf.as_ptr(), dest_rect.Right as usize)
+    // };
+    // tuitty::terminal::actions::win32::printf(
+    //     &format!("{:?}", unsafe {
+    //         buf[19].Char.UnicodeChar()
+    //     }), false
+    // );
+    // // tuitty::terminal::actions::win32::printf(
+    // //     &format!("{:?}", unsafe {
+    // //         chinfo.Char.UnicodeChar_mut()
+    // //     }), false);
+
+    // // Try modifying read buffer?
+    // // let patch = "--".encode_utf16();
+    // // let patch = "--".bytes();
+    // #[cfg(not(windows))]
+    // let patch = "😀".encode_utf16();
+    // #[cfg(windows)]
+    // let patch: Vec<u16> = OsStr::new("👪").encode_wide().collect();
+    // // patch 1
+    // // let mut index = 20; // contingent on knowing the correct index...
+    // let mut index = 9 * 85 + 12;
+    // for i in patch {
+    //     unsafe {
+    //         *read_buf[index].Char.UnicodeChar_mut() = i;
+    //         // *read_buf[index].Char.AsciiChar_mut() = i as i8;
+    //     }
+    //     index += 1;
+    // }
+    // // patch 2 (coord: row 8, x: 15)
+    // // let patch = "--".encode_utf16();
+    // let patch: Vec<u16> = OsStr::new("--").encode_wide().collect();
+    // // let patch = "--".bytes();
+    // let mut index = 9 * 85 + 15;
+    // for i in patch {
+    //     // unsafe {
+    //     //     let mut ch_info: CHAR_INFO = zeroed();
+    //     //     ch_info.Attributes = attrs;
+    //     //     *ch_info.Char.UnicodeChar_mut() = i;
+    //     //     // *ch_info.Char.AsciiChar_mut() = i as i8;
+    //     //     read_buf[index] = ch_info;
+    //     // }
+    //     unsafe {
+    //         *read_buf[index].Char.UnicodeChar_mut() = i;
+    //         // *read_buf[index].Char.AsciiChar_mut() = i as i8;
+    //     }
+    //     index += 1;
+    // }
+
+
+    // let read_u16: Vec<u16> = read_buf.iter().map(|x| unsafe { *x.Char.UnicodeChar() }).collect();
+    // let read_string: String = String::from_utf16_lossy(&read_u16);
+    // let mut index = 0;
+    // for u in OsStr::new(&read_string).encode_wide() {
+    //     unsafe {
+    //         *read_buf[index].Char.UnicodeChar_mut() = u;    
+    //     }
+    //     index += 1;
+    // };
+
+
+
+    let buf_modded = unsafe {
+        WriteConsoleOutputW(
+        // WriteConsoleOutputA(
+            altern.0, 
+            read_buf.as_ptr(), 
+            COORD {X: 85, Y: 29},
+            COORD {X: 0, Y: 0},
+            &mut SMALL_RECT {
+                Top: 0,
+                Left: 0,
+                Bottom: 29,
+                Right: 85,
+            })
+    };
+
+    if buf_modded == 0 { 
+        tuitty::terminal::actions::win32::cook();
+        tuitty::terminal::actions::win32::disable_alt(false);
+        panic!("Something went wrong copying buffer");
+    }
+
+
+    // Attempt to fill the screen using iteration
+    // let w = "😀".encode_utf16();
+    // let w_info_buf = w.map(|ch| unsafe {
+    //     let mut char_info: CHAR_INFO = zeroed();
+    //     char_info.Attributes = attrs;
+    //     *char_info.Char.UnicodeChar_mut() = ch;
+    //     char_info
+    // }).collect::<Vec<CHAR_INFO>>();
+    // for i in 0..30 {
+    //     for j in 0..86 {
+    //     let buf_iter = unsafe {
+    //         WriteConsoleOutputW(
+    //             altern.0, 
+    //             w_info_buf.as_ptr(), 
+    //             COORD {X: 1, Y: 1},
+    //             COORD {X: 0, Y: 0},
+    //             &mut SMALL_RECT {
+    //                 Top: i,
+    //                 Left: j,
+    //                 Bottom: 29,
+    //                 Right: 85,
+    //             }
+    //         )
+    //     };
+    //     if buf_iter == 0 { 
+    //         tuitty::terminal::actions::win32::cook();
+    //         tuitty::terminal::actions::win32::disable_alt(false);
+    //         panic!("Something went wrong iterating buffer");
+    //     }
+    // }}
+
+
+
+    // Example full buffer fill
+    // let w = "😀".repeat(85*29);
+    // let w = w.encode_utf16();
+    // let w_info_buf = w.map(|ch| unsafe {
+    //     let mut char_info: CHAR_INFO = zeroed();
+    //     char_info.Attributes = attrs;
+    //     *char_info.Char.UnicodeChar_mut() = ch;
+    //     char_info
+    // }).collect::<Vec<CHAR_INFO>>();
+
+    // let buf_iter = unsafe {
+    //     WriteConsoleOutputW(
+    //         altern.0, 
+    //         w_info_buf.as_ptr(), 
+    //         COORD {X: 86, Y: 30},
+    //         COORD {X: 0, Y: 0},
+    //         &mut SMALL_RECT {
+    //             Top: 0,
+    //             Left: 0,
+    //             Bottom: 29,
+    //             Right: 85,
+    //         }
+    //     )
+    // };
+
+    // if buf_iter == 0 { 
+    //     tuitty::terminal::actions::win32::cook();
+    //     tuitty::terminal::actions::win32::disable_alt(false);
+    //     panic!("Something went wrong iterating buffer");
+    // }
+
+    thread::sleep(Duration::from_millis(5000));
+
+    tuitty::terminal::actions::win32::cook();
+    tuitty::terminal::actions::win32::disable_alt(false);
+}

--- a/examples/windows_write.rs
+++ b/examples/windows_write.rs
@@ -99,7 +99,7 @@ fn main() {
 
     // Read contents
     // let mut read_buf: Vec<CHAR_INFO> = Vec::with_capacity(len);
-    let mut read_buf: Vec<CHAR_INFO> = unsafe { vec![zeroed(); 85 * 29 * 4] };
+    let mut read_buf: Vec<CHAR_INFO> = unsafe { vec![zeroed(); 86 * 30] };
     // let mut read_buf = unsafe { vec![zeroed(); 85 * 29 * 4] };
     let buf_read = unsafe {
         ReadConsoleOutputW(
@@ -116,56 +116,86 @@ fn main() {
         panic!("Something went wrong reading buffer");
     }
 
-    let read_u16: Vec<u16> = read_buf.iter().map(|x| unsafe { *x.Char.UnicodeChar() }).collect();
-    let read_string: String = String::from_utf16_lossy(&read_u16);
-    tuitty::terminal::actions::win32::goto(0, 0, false);
-    let mut written = 0;
-    let res = unsafe {
-        WriteConsoleW(
-            altern.0,
-            read_string.as_ptr() as *const c_void,
-            85 * 29,
-            &mut written, null_mut()
-        )
-    };
-    if res == 0 {
-            tuitty::terminal::actions::win32::cook();
-            tuitty::terminal::actions::win32::disable_alt(false);
-            panic!("Something went wrong pasting buffer");
-    }
+    // let read_u16: Vec<u16> = read_buf.iter().map(|x| unsafe { *x.Char.UnicodeChar() }).collect();
+    // let read_string: String = String::from_utf16_lossy(&read_u16);
+    // tuitty::terminal::actions::win32::goto(0, 0, false);
+    // let mut written = 0;
+    // let res = unsafe {
+    //     WriteConsoleW(
+    //         altern.0,
+    //         read_string.as_ptr() as *const c_void,
+    //         85 * 29,
+    //         &mut written, null_mut()
+    //     )
+    // };
+    // if res == 0 {
+    //         tuitty::terminal::actions::win32::cook();
+    //         tuitty::terminal::actions::win32::disable_alt(false);
+    //         panic!("Something went wrong pasting buffer");
+    // }
     
 
+    let mut index = 0;
+    // for u in "qwertyuiopasd⚠️fghjkl🚧園v明nmQWE👪RTY👨‍👩‍👧UIOPASDFGHJKLZXCVBNM".encode_utf16() {
+    for u in OsStr::new("qwertyuiopasd⚠️fghjkl🚧園v明nmQWE👪RTY👨‍👩‍👧UIOPASDFGHJKLZXCVBNM").encode_wide() {
+        unsafe {
+            *read_buf[index].Char.UnicodeChar_mut() = u;    
+        }
+        index += 1;
+    };
 
-    // let mut index = 0;
-    // for u in OsStr::new(&read_string).encode_wide() {
+    // let mut index = 22;
+    // for u in OsStr::new("🚧").encode_wide() {
+    //     unsafe {
+    //         *read_buf[index].Char.UnicodeChar_mut() = u;    
+    //     }
+    //     index += 1;
+    // };
+    // index = 23;
+    // for u in OsStr::new(&format!("{}", index)).encode_wide() {
+    //     unsafe {
+    //         *read_buf[index].Char.UnicodeChar_mut() = u;    
+    //     }
+    //     index += 1;
+    // };
+    // index = 26;
+    // for u in OsStr::new("T").encode_wide() {
+    //     unsafe {
+    //         *read_buf[index].Char.UnicodeChar_mut() = u;    
+    //     }
+    //     index += 1;
+    // };
+    // index = 28;
+    // for u in OsStr::new("K").encode_wide() {
     //     unsafe {
     //         *read_buf[index].Char.UnicodeChar_mut() = u;    
     //     }
     //     index += 1;
     // };
 
-    // // Copy contents over
-    // let buf_copy = unsafe {
-    //     WriteConsoleOutputW(
-    //     // WriteConsoleOutputA(
-    //         altern.0, 
-    //         read_buf.as_ptr(), 
-    //         // COORD {X: len as i16, Y: 1},
-    //         COORD {X: 51, Y: 1},
-    //         COORD {X: 0, Y: 0},
-    //         &mut SMALL_RECT {
-    //             Top: 5,
-    //             Left: 5,
-    //             Bottom: 29,
-    //             Right: 85,
-    //         })
-    // };
 
-    // if buf_copy == 0 { 
-    //     tuitty::terminal::actions::win32::cook();
-    //     tuitty::terminal::actions::win32::disable_alt(false);
-    //     panic!("Something went wrong copying buffer");
-    // }
+    // Copy contents over
+    let buf_copy = unsafe {
+        WriteConsoleOutputW(
+        // WriteConsoleOutputA(
+            altern.0, 
+            read_buf.as_ptr(), 
+            // COORD {X: len as i16, Y: 1},
+            COORD {X: 51, Y: 1},
+            COORD {X: 0, Y: 0},
+            &mut SMALL_RECT {
+                Top: 5,
+                Left: 5,
+                Bottom: 29,
+                Right: 85,
+            })
+    };
+
+    if buf_copy == 0 { 
+        tuitty::terminal::actions::win32::cook();
+        tuitty::terminal::actions::win32::disable_alt(false);
+        panic!("Something went wrong copying buffer");
+    }
 
     thread::sleep(Duration::from_millis(2000));
 

--- a/src/common/enums.rs
+++ b/src/common/enums.rs
@@ -59,6 +59,139 @@ pub enum Color {
     AnsiValue(u8),
 }
 
+#[cfg(windows)]
+pub const RESET: u16 = 0xFFFF;
+#[cfg(windows)]
+pub const IGNORE: u16 = 0xFFF0;
+
+#[cfg(windows)]
+use winapi::um::wincon::{
+    COMMON_LVB_UNDERSCORE as UNDERLINE,
+    COMMON_LVB_REVERSE_VIDEO as REVERSE,
+    FOREGROUND_RED as FG_RED,
+    FOREGROUND_GREEN as FG_GREEN,
+    FOREGROUND_BLUE as FG_BLUE,
+    FOREGROUND_INTENSITY as FG_INTENSE,
+    BACKGROUND_RED as BG_RED,
+    BACKGROUND_GREEN as BG_GREEN,
+    BACKGROUND_BLUE as BG_BLUE,
+    BACKGROUND_INTENSITY as BG_INTENSE,
+};
+
+#[cfg(windows)]
+pub fn foreground(color: Color, current: u16, reset: u16) -> u16 {
+    let mut attrib = match color {
+        Color::Black => 0,
+        Color::DarkGrey => FG_INTENSE,
+        Color::Red => FG_RED | FG_INTENSE,
+        Color::DarkRed => FG_GREEN,
+        Color::Green => FG_GREEN | FG_INTENSE,
+        Color::DarkGreen => FG_GREEN,
+        Color::Yellow => FG_RED | FG_GREEN | FG_INTENSE,
+        Color::DarkYellow => FG_RED | FG_GREEN,
+        Color::Blue => FG_BLUE | FG_INTENSE,
+        Color::DarkBlue => FG_BLUE,
+        Color::Magenta => FG_RED | FG_BLUE | FG_INTENSE,
+        Color::DarkMagenta => FG_RED | FG_BLUE,
+        Color::Cyan => FG_GREEN | FG_BLUE | FG_INTENSE,
+        Color::DarkCyan => FG_GREEN | FG_BLUE,
+        Color::White => FG_RED | FG_GREEN | FG_BLUE,
+        Color::Grey => FG_RED | FG_GREEN | FG_BLUE | FG_INTENSE,
+        Color::Reset => RESET,
+        Color::Rgb{r, g, b} => IGNORE,
+        Color::AnsiValue(_) => IGNORE,
+    };
+    if attrib == RESET {
+        attrib = reset & 0x000f;
+    }
+    if attrib == IGNORE {
+        attrib = current & 0x000f;
+    }
+    // (imdaveho) NOTE: We need to isolate Colors in Windows
+    // because Color attributes mix. So if you previously had
+    // Color::Red and you wanted Color::Blue, that would end up
+    // as Color::Magenta if you didn't first clear it out
+    // attrib | just_bg | just_fx
+    attrib | current & !0x000f
+}
+
+#[cfg(windows)]
+pub fn background(color: Color, current: u16, reset: u16) -> u16 {
+    let mut attrib = match color {
+        Color::Black => 0,
+        Color::DarkGrey => BG_INTENSE,
+        Color::Red => BG_RED | BG_INTENSE,
+        Color::DarkRed => BG_GREEN,
+        Color::Green => BG_GREEN | BG_INTENSE,
+        Color::DarkGreen => BG_GREEN,
+        Color::Yellow => BG_RED | BG_GREEN | BG_INTENSE,
+        Color::DarkYellow => BG_RED | BG_GREEN,
+        Color::Blue => BG_BLUE | BG_INTENSE,
+        Color::DarkBlue => BG_BLUE,
+        Color::Magenta => BG_RED | BG_BLUE | BG_INTENSE,
+        Color::DarkMagenta => BG_RED | BG_BLUE,
+        Color::Cyan => BG_GREEN | BG_BLUE | BG_INTENSE,
+        Color::DarkCyan => BG_GREEN | BG_BLUE,
+        Color::White => BG_RED | BG_GREEN | BG_BLUE,
+        Color::Grey => BG_RED | BG_GREEN | BG_BLUE | BG_INTENSE,
+        Color::Reset => RESET,
+        Color::Rgb{r, g, b} => IGNORE,
+        Color::AnsiValue(_) => IGNORE,
+    };
+    if attrib == RESET {
+        attrib = reset & 0x00f0;
+    }
+    if attrib == IGNORE {
+        attrib = current & 0x00f0;
+    }
+    // (imdaveho) NOTE: We need to isolate Colors in Windows
+    // because Color attributes mix. So if you previously had
+    // Color::Red and you wanted Color::Blue, that would end up
+    // as Color::Magenta if you didn't first clear it out
+    // just_fg | attrib | just_fx
+    attrib | current & !0x00f0
+    
+}
+
+#[cfg(windows)]
+pub fn effects(fx: u32, current: u16) -> u16 {
+    let mut attrib = current;
+    let available_effects = [
+        Effect::Reset, 
+        Effect::Bold, 
+        Effect::Dim, 
+        Effect::Underline, 
+        Effect::Reverse, 
+        Effect::Hide
+    ];
+    for effect in &available_effects {
+        if (fx & *effect as u32) != 0 {
+            match *effect {
+                Effect::Bold => attrib |= FG_INTENSE,
+                Effect::Dim => attrib &= !FG_INTENSE,
+                Effect::Underline => attrib |= UNDERLINE,
+                Effect::Reverse => attrib |= REVERSE,
+                Effect::Hide => {
+                    // FOREGROUND and BACKGROUND color differ by 4
+                    // bits; to convert from 0x0020 (BG Green) to
+                    // 0x0002 (FG Green), shift right 4 bits. By
+                    // making the FOREGROUND color the same as the
+                    // BACKGROUND color, effectively you hide the
+                    // printed content.
+                    let updated_fg = (current & 0x00f0) >> 4;
+                    // Since we identified the new FOREGROUND, we
+                    // include it and remove it from the current
+                    // attributes. The BACKGROUND should remain the
+                    // same within the current attrs.
+                    attrib = updated_fg | current & !0x000f
+                },
+                Effect::Reset => attrib = current & !0xdf00,
+            }
+        }
+    }
+    attrib
+}
+
 
 #[derive(Clone, Copy, PartialEq)]
 pub enum Effect {

--- a/src/terminal/actions/mod.rs
+++ b/src/terminal/actions/mod.rs
@@ -462,7 +462,9 @@ pub mod win32 {
     // UNIFIED STRUCT W/ ACTIONS
     pub struct Term {
         mode: u32,
-        reset: i16,
+        #[cfg(windows)]
+        reset: ConsoleInfo,
+        #[cfg(windows)]
         conout: Handle,
         //conin: Handle,
         cfg: bool

--- a/src/terminal/actions/wincon/cursor.rs
+++ b/src/terminal/actions/wincon/cursor.rs
@@ -37,7 +37,7 @@ pub fn goto(col: i16, row: i16) -> Result<()> {
             return Err(Error::last_os_error());
         }
     }
-
+    handle.close()?;
     Ok(())
 }
 
@@ -72,6 +72,7 @@ pub fn hide_cursor() -> Result<()> {
             return Err(Error::last_os_error());
         }
     }
+    handle.close()?;
     Ok(())
 }
 
@@ -86,11 +87,13 @@ pub fn show_cursor() -> Result<()> {
             return Err(Error::last_os_error());
         }
     }
+    handle.close()?;
     Ok(())
 }
 
 pub fn pos() -> Result<(i16, i16)> {
     let handle = Handle::conout()?;
     let info = ConsoleInfo::of(&handle)?;
+    handle.close()?;
     Ok(info.cursor_pos())
 }

--- a/src/terminal/actions/wincon/handle.rs
+++ b/src/terminal/actions/wincon/handle.rs
@@ -127,15 +127,20 @@ impl Handle {
     // https://docs.microsoft.com/en-us/windows/win32/api/
     // handleapi/nf-handleapi-closehandle
     pub fn close(&self) -> Result<()> {
-        let stdin = Handle::stdin()?;
-        let stdout = Handle::stdout()?;
-        if self.0 == stdin.0 || self.0 == stdout.0 {
-            return Ok(());
-        } else {
-            unsafe {
-                if CloseHandle(self.0) == 0 {
-                    return Err(Error::last_os_error())
-                }
+        // let stdin = Handle::stdin()?;
+        // let stdout = Handle::stdout()?;
+        // if self.0 == stdin.0 || self.0 == stdout.0 {
+        //     return Ok(());
+        // } else {
+        //     unsafe {
+        //         if CloseHandle(self.0) == 0 {
+        //             return Err(Error::last_os_error())
+        //         }
+        //     }
+        // }
+        unsafe {
+            if CloseHandle(self.0) == 0 {
+                return Err(Error::last_os_error())
             }
         }
         Ok(())

--- a/src/terminal/actions/wincon/mouse.rs
+++ b/src/terminal/actions/wincon/mouse.rs
@@ -12,6 +12,7 @@ pub fn enable_mouse_mode() -> Result<()> {
     let mode = handle.get_mode()?;
     let mouse_mode = (mode | MOUSE_MODE) & !0x0040;
     handle.set_mode(&mouse_mode)?;
+    handle.close()?;
     Ok(())
 }
 
@@ -20,5 +21,6 @@ pub fn disable_mouse_mode() -> Result<()> {
     let mode = handle.get_mode()?;
     let mouse_mode = (mode & !MOUSE_MODE) | 0x0040;
     handle.set_mode(&mouse_mode)?;
+    handle.close()?;
     Ok(())
 }

--- a/src/terminal/actions/wincon/output.rs
+++ b/src/terminal/actions/wincon/output.rs
@@ -45,6 +45,7 @@ pub fn prints(content: &str) -> Result<usize> {
             return Err(Error::last_os_error());
         }
     }
+    handle.close()?;
     Ok(size as usize)
 }
 
@@ -53,7 +54,10 @@ pub fn get_mode() -> Result<u32> {
     // Stdout because if you're creating a
     // new screen via alternate screen, you
     // want a default set of terminal settings
-    Handle::stdout().unwrap().get_mode()
+    let handle = Handle::stdout()?;
+    let mode = handle.get_mode();
+    handle.close()?;
+    mode
 }
 
 
@@ -63,6 +67,7 @@ pub fn enable_raw() -> Result<()> {
     let mask = ENABLE_WRAP_AT_EOL_OUTPUT | ENABLE_LINE_INPUT;
     let raw_mode = mode & !mask;
     handle.set_mode(&raw_mode)?;
+    handle.close()?;
     Ok(())
 }
 
@@ -72,5 +77,6 @@ pub fn disable_raw() -> Result<()> {
     let mask = ENABLE_WRAP_AT_EOL_OUTPUT | ENABLE_LINE_INPUT;
     let cooked_mode = mode | mask;
     handle.set_mode(&cooked_mode)?;
+    handle.close()?;
     Ok(())
 }

--- a/src/terminal/actions/wincon/style.rs
+++ b/src/terminal/actions/wincon/style.rs
@@ -22,6 +22,7 @@ pub fn reset(reset_style: u16) -> Result<()> {
             return Err(Error::last_os_error());
         }
     }
+    // handle.close()?;
     Ok(())
 }
 

--- a/src/terminal/actions/wincon/style.rs
+++ b/src/terminal/actions/wincon/style.rs
@@ -1,18 +1,12 @@
 // Windows Console API specific functions to style text output to the terminal.
 
 use std::io::{Error, Result};
-use winapi::um::wincon::{
-    SetConsoleTextAttribute,
-    FOREGROUND_INTENSITY as INTENSE,
-    COMMON_LVB_UNDERSCORE as UNDERLINE,
-    COMMON_LVB_REVERSE_VIDEO as REVERSE
-};
+use winapi::um::wincon::SetConsoleTextAttribute;
 use super::handle::{Handle, ConsoleInfo};
-use crate::common::enums::{Style, Color, Effect::*};
-
-
-pub const RESET: u16 = 0xFFFF;
-pub const IGNORE: u16 = 0xFFF0;
+use crate::common::enums::{
+    Style, Color,
+    foreground, background, effects
+};
 
 
 pub fn reset(reset_style: u16) -> Result<()> {
@@ -34,65 +28,14 @@ pub fn set_style(style: Style, reset_style: u16) -> Result<()> {
     //     current & 0x000f, current & 0x00f0, current & 0xdf00);
     let updated: u16 = match style {
         Style::Fg(c) => {
-            let mut updated_fg = Foreground::from(c);
-            if updated_fg == RESET {
-                updated_fg = Foreground(reset_style & 0x000f)
-            }
-            if updated_fg == IGNORE {
-                updated_fg = Foreground(current & 0x000f)
-            }
-            // (imdaveho) NOTE: We need to isolate Colors in Windows
-            // because Color attributes mix. So if you previously had
-            // Color::Red and you wanted Color::Blue, that would end up
-            // as Color::Magenta if you didn't first clear it out
-            // updated_fg.0 | just_bg | just_fx
-            updated_fg.0 | current & !0x000f
+            foreground(c, current, reset_style)
         },
         Style::Bg(c) => {
-            let mut updated_bg = Background::from(c);
-            if updated_bg == RESET {
-                updated_bg = Background(reset_style & 0x00f0)
-            }
-            if updated_bg == IGNORE {
-                updated_bg = Background(current & 0x00f0)
-            }
-            // (imdaveho) NOTE: We need to isolate Colors in Windows
-            // because Color attributes mix. So if you previously had
-            // Color::Red and you wanted Color::Blue, that would end up
-            // as Color::Magenta if you didn't first clear it out
-            // just_fg | updated_bg.0 | just_fx
-            updated_bg.0 | current & !0x00f0
+            background(c, current, reset_style)
         },
         Style::Fx(f) => {
-            let fxs = [Reset, Bold, Dim, Underline, Reverse, Hide];
-            let mut updates = current;
-            for fx in &fxs {
-                if (f & *fx as u32) != 0 {
-                    match *fx {
-                        Bold => updates |= INTENSE,
-                        Dim => updates &= !INTENSE,
-                        Underline => updates |= UNDERLINE,
-                        Reverse => updates |= REVERSE,
-                        Hide => {
-                            // FOREGROUND and BACKGROUND color differ by 4
-                            // bits; to convert from 0x0020 (BG Green) to
-                            // 0x0002 (FG Green), shift right 4 bits. By
-                            // making the FOREGROUND color the same as the
-                            // BACKGROUND color, effectively you hide the
-                            // printed content.
-                            let updated_fg = (current & 0x00f0) >> 4;
-                            // Since we identified the new FOREGROUND, we
-                            // include it and remove it from the current
-                            // attributes. The BACKGROUND should remain the
-                            // same within the current attrs.
-                            updates = updated_fg | current & !0x000f
-                        },
-                        Reset => updates = current & !0xdf00,
-                    }
-                }
-            }
-            updates
-        },
+            effects(f, current)
+        }
     };
     unsafe {
         if SetConsoleTextAttribute(handle.0, updated) == 0 {
@@ -107,87 +50,4 @@ pub fn set_styles(fg: Color, bg: Color, fx: u32, reset_style: u16) -> Result<()>
     set_style(Style::Bg(bg), reset_style)?;
     set_style(Style::Fx(fx), reset_style)?;
     Ok(())
-}
-
-
-struct Foreground(u16);
-
-impl From<Color> for Foreground {
-    fn from(src: Color) -> Self {
-        use winapi::um::wincon::{
-            FOREGROUND_RED as RED,
-            FOREGROUND_GREEN as GREEN,
-            FOREGROUND_BLUE as BLUE,
-        };
-
-        match src {
-            Color::Black => Self(0),
-            Color::DarkGrey => Self(INTENSE),
-            Color::Red => Self(RED | INTENSE),
-            Color::DarkRed => Self(GREEN),
-            Color::Green => Self(GREEN | INTENSE),
-            Color::DarkGreen => Self(GREEN),
-            Color::Yellow => Self(RED | GREEN | INTENSE),
-            Color::DarkYellow => Self(RED | GREEN),
-            Color::Blue => Self(BLUE | INTENSE),
-            Color::DarkBlue => Self(BLUE),
-            Color::Magenta => Self(RED | BLUE | INTENSE),
-            Color::DarkMagenta => Self(RED | BLUE),
-            Color::Cyan => Self(GREEN | BLUE | INTENSE),
-            Color::DarkCyan => Self(GREEN | BLUE),
-            Color::White => Self(RED | GREEN | BLUE),
-            Color::Grey => Self(RED | GREEN | BLUE | INTENSE),
-            Color::Reset => Self(RESET),
-            Color::Rgb{r, g, b} => Self(IGNORE),
-            Color::AnsiValue(_) => Self(IGNORE),
-        }
-    }
-}
-
-impl PartialEq<u16> for Foreground {
-    fn eq(&self, other: &u16) -> bool {
-        self.0 == (*other)
-    }
-}
-
-
-struct Background(u16);
-
-impl From<Color> for Background {
-    fn from(src: Color) -> Self {
-        use winapi::um::wincon::{
-            BACKGROUND_RED as RED,
-            BACKGROUND_GREEN as GREEN,
-            BACKGROUND_BLUE as BLUE,
-            BACKGROUND_INTENSITY as INTENSE,
-        };
-
-        match src {
-            Color::Black => Self(0),
-            Color::DarkGrey => Self(INTENSE),
-            Color::Red => Self(RED | INTENSE),
-            Color::DarkRed => Self(GREEN),
-            Color::Green => Self(GREEN | INTENSE),
-            Color::DarkGreen => Self(GREEN),
-            Color::Yellow => Self(RED | GREEN | INTENSE),
-            Color::DarkYellow => Self(RED | GREEN),
-            Color::Blue => Self(BLUE | INTENSE),
-            Color::DarkBlue => Self(BLUE),
-            Color::Magenta => Self(RED | BLUE | INTENSE),
-            Color::DarkMagenta => Self(RED | BLUE),
-            Color::Cyan => Self(GREEN | BLUE | INTENSE),
-            Color::DarkCyan => Self(GREEN | BLUE),
-            Color::White => Self(RED | GREEN | BLUE),
-            Color::Grey => Self(RED | GREEN | BLUE | INTENSE),
-            Color::Reset => Self(RESET),
-            Color::Rgb{r, g, b} => Self(IGNORE),
-            Color::AnsiValue(_) => Self(IGNORE),
-        }
-    }
-}
-
-impl PartialEq<u16> for Background {
-    fn eq(&self, other: &u16) -> bool {
-        self.0 == (*other)
-    }
 }

--- a/src/terminal/actions/wincon/style.rs
+++ b/src/terminal/actions/wincon/style.rs
@@ -1,7 +1,11 @@
 // Windows Console API specific functions to style text output to the terminal.
 
 use std::io::{Error, Result};
-use winapi::um::wincon::SetConsoleTextAttribute;
+use winapi::um::wincon::{
+    COORD,
+    SetConsoleTextAttribute, WriteConsoleOutputAttribute
+};
+use winapi::shared::minwindef::WORD;
 use super::handle::{Handle, ConsoleInfo};
 use crate::common::enums::{
     Style, Color,
@@ -16,7 +20,7 @@ pub fn reset(reset_style: u16) -> Result<()> {
             return Err(Error::last_os_error());
         }
     }
-    // handle.close()?;
+    handle.close()?;
     Ok(())
 }
 
@@ -42,6 +46,7 @@ pub fn set_style(style: Style, reset_style: u16) -> Result<()> {
             return Err(Error::last_os_error());
         }
     }
+    handle.close()?;
     Ok(())
 }
 
@@ -49,5 +54,27 @@ pub fn set_styles(fg: Color, bg: Color, fx: u32, reset_style: u16) -> Result<()>
     set_style(Style::Fg(fg), reset_style)?;
     set_style(Style::Bg(bg), reset_style)?;
     set_style(Style::Fx(fx), reset_style)?;
+    Ok(())
+}
+
+// Windows Console API specific. Allows you to update the text
+// styles without having to re-print. 
+pub fn set_attribute(word: u16, length: u32, coord: (i16, i16)) -> Result<()> {
+    let handle = Handle::conout()?;
+
+    let mut count = 0;
+    let set: Vec<WORD> = vec![word as WORD; length as usize];
+    let ptr: *const WORD = set.as_ptr() as *const WORD;
+
+    unsafe {
+        if WriteConsoleOutputAttribute(
+            handle.0, 
+            ptr, length, 
+            COORD {X: coord.0, Y: coord.1}, 
+            &mut count) == 0 {
+                return Err(Error::last_os_error());
+            }
+    }
+    handle.close()?;
     Ok(())
 }

--- a/src/terminal/dispatch/mod.rs
+++ b/src/terminal/dispatch/mod.rs
@@ -686,7 +686,7 @@ impl Dispatcher {
     pub fn listen(&mut self) -> EventHandle {
         // Do not duplicate threads.
         // If input handle exists don't do anything.
-        if let Some(_) = self.input_handle { return self.spawn() }
+        if self.input_handle.is_some() { return self.spawn() }
 
         // Setup input channel and Arc's to move to thread.
         let is_running = self.is_running.clone();

--- a/src/terminal/dispatch/parser/windows/mod.rs
+++ b/src/terminal/dispatch/parser/windows/mod.rs
@@ -123,6 +123,13 @@ pub fn read_input_events() -> (u32, Vec<InputEvent>) {
         }
     }
 
+    // TODO: needs testing -- try to put in dispatcher and pass as ref
+    // as well as test rapid create/close/create/close/create/close...
+    // match conin.close() {
+    //     Ok() => (),
+    //     Err(_) => return (0, vec![InputEvent::Unsupported]),
+    // };
+
     let result = (
         buf_len,
         buf[..(buf_len as usize)]

--- a/src/terminal/store/buffer.rs
+++ b/src/terminal/store/buffer.rs
@@ -122,7 +122,7 @@ impl Buffer {
             }
             Clear::CursorDn => {
                 let index = self.cursor();
-                let ((w, h), (col, row)) = (self.size(),
+                let (w, h, (col, row)) = (self.width, self.height,
                                             self.coord(index));
                 let (start, stop) = (
                     ((row * w) + col) as usize,
@@ -608,62 +608,6 @@ impl Buffer {
         output
     }
 }
-
-
-// fn pos_raw() -> (i16, i16) {
-//     use std::io::{ Write, BufRead };
-//     let ln = 603;
-//     // Where is the cursor?
-//     // Use `ESC [ 6 n`.
-//     let mut stdout = std::io::stdout();
-//     let stdin = std::io::stdin();
-
-//     // Write command
-//     stdout.write_all(b"\x1B[6n").expect(&format!(
-//         "buffer.rs [Ln: {}]: Error writing to stdout", ln + 9));
-//     stdout.flush().expect(&format!(
-//         "buffer.rs [Ln: {}]: Error flushing stdout", ln + 11));
-
-//     stdin.lock().read_until(b'[', &mut vec![]).expect(&format!(
-//         "buffer.rs [Ln {}]: Error reading stdin", ln + 14));
-
-//     let mut rows = vec![];
-//     stdin.lock().read_until(b';', &mut rows).expect(&format!(
-//         "buffer.rs [Ln {}]: Error reading stdin", ln + 18));
-
-//     let mut cols = vec![];
-//     stdin.lock().read_until(b'R', &mut cols).expect(&format!(
-//         "buffer.rs [Ln {}]: Error reading stdin", ln + 22));
-
-//     // remove delimiter
-//     rows.pop();
-//     cols.pop();
-
-//     let rows = rows
-//         .into_iter()
-//         .map(|b| (b as char))
-//         .fold(String::new(), |mut acc, n| {
-//             acc.push(n);
-//             acc
-//         })
-//         .parse::<usize>()
-//         .expect(&format!(
-//             "buffer.rs [Ln {}]: Error parsing row position.", ln + 29
-//         ));
-//     let cols = cols
-//         .into_iter()
-//         .map(|b| (b as char))
-//         .fold(String::new(), |mut acc, n| {
-//             acc.push(n);
-//             acc
-//         })
-//         .parse::<usize>()
-//         .expect(&format!(
-//             "buffer.rs [Ln {}]: Error parsing col position.", ln + 40
-//         ));
-
-//     ((cols - 1) as i16, (rows - 1) as i16)
-// }
 
 
 #[cfg(test)]

--- a/src/terminal/store/buffer.rs
+++ b/src/terminal/store/buffer.rs
@@ -477,7 +477,6 @@ impl Buffer {
                             } else {
                                 cutoff += std::mem::size_of_val(grphm);
                                 self.strbuf.push(car);
-                                let cell = ;
                                 let reset = self.patch(
                                     Cell::Double(car, 2, self.style),
                                     index, cutoff);

--- a/src/terminal/store/buffer.rs
+++ b/src/terminal/store/buffer.rs
@@ -17,134 +17,311 @@ use crate::terminal::actions::posix;
 use crate::terminal::actions::win32;
 
 
-#[derive(Clone)]
-enum Content {
-    Single(char),
-    Double(char),
-    Complex(Vec<char>),
-    Pointer(usize, usize),
-    Blank,
+#[derive(Clone, PartialEq)]
+enum Cell {
+    Single{ value: char, width: usize, style: (Color, Color, u32) },
+    Double{ value: char, width: usize, style: (Color, Color, u32) },
+    Vector{ value: Vec<char>, width: usize, style: (Color, Color, u32) },
+    // Linker is used for complex unicode values kept in a Vector. It
+    // contains index offsets to the left and right from its position.
+    Linker(usize, usize),
+    TAB, NIL
 }
 
 
-#[derive(Clone)]
-pub struct Cell {
-    content: Content,
-    style: (Color, Color, u32),
-    is_dirty: bool,
-}
-
-impl Default for Cell {
-    fn default() -> Self {
-        Self {
-            content: Content::Blank,
-            style: (Reset, Reset, Effect::Reset as u32),
-            is_dirty: false
-        }
-    }
+// e.g. ansi
+// [ goto(x,y), print(s), goto(x, y), print(s), ..., goto(cursor) ] + flush()
+// e.g. windows (unused)
+// [ writeconsoleoutput{ rect }, writeconsoleoutput{ rect }, ... ]
+// In both cases, the cursor returns to where it needs to be after executing.
+enum Edit {
+    Index(usize),
+    Content(String),
+    Styling(Color, Color, u32),
 }
 
 
 pub struct Buffer {
-    cursor: usize,
-    cells: Vec<Cell>,
-    capacity: usize,
-    // window: (i16, i16),
-    // tab_size: usize,
-    // marked_pos: usize,
-    // active_style: (Color, Color, u32)
+    index: usize,
+    cells: Vec<Cell>,  // for get ch at point
+    edits: Vec<Edit>,  // for updating stdout
+    width: i16,
+    height: i16,
+    style: (Color, Color, u32),
+    tabwidth: usize,
+    savedpos: usize,
+    // treatment: usize, // 0: no zwj; 1: zwj; 2: zwj+fitz; default: 0
 }
 
 impl Buffer {
     pub fn new() -> Self {
         #[cfg(unix)]
-        let (w, h) = posix::size();
+        let (width, height) = posix::size();
         #[cfg(windows)]
-        let (w, h) = win32::size();
-        let cursor = 0;
-        let capacity = (w * h) as usize;
-        let cells = vec![Default::default(); capacity];
-        Self { cursor, cells, capacity }
+        let (width, height) = win32::size();
+        let capacity = (width * height) as usize;
+        Self {
+            index: 0,
+            cells: vec![Cell::NIL; capacity],
+            edits: Vec::with_capacity(12),
+            width,
+            height,
+            style: (Reset, Reset, Effect::Reset as u32),
+            tabwidth: 8,
+            savedpos: 0,
+            // treatment: 0,
+        }
     }
 
-    pub fn cursor(&mut self) -> usize {
-        let mut index = self.cursor;
-        match self.cells.get(index) {
-            Some(c) => match c.content {
-                Content::Pointer(a, _) => a,
-                _ => index
-            },
+    // pub fn treatment(&mut self, level: usize) {
+    //     self.treatment = level;
+    // }
+
+    // Returns a coordinate tuple from an index.
+    // Does NOT update internal index.
+    pub fn coord(&self, index: usize) -> (i16, i16) {
+        let width = self.width;
+        let index = index as i16;
+        ((index % width), (index / width))
+    }
+
+    // Returns an index from a coordinate tuple.
+    // Does NOT update internal index.
+    pub fn index(&self, coord: (i16, i16)) -> usize {
+        let (mut col, mut row) = (coord.0, coord.1);
+        if col < 0 { col = col.abs() }
+        if row < 0 { row = row.abs() }
+        ((row * self.width) + col) as usize
+    }
+
+    // Returns t next tabstop given a tab length from a coordinate tuple.
+    // Does NOT update internal index.
+    pub fn tabstop(&self, coord: (i16, i16)) -> usize {
+        let (col, row) = (coord.0, coord.1);
+        // 1. handle new tab stop:
+        let prev_stop = (col as usize / self.tabwidth) * self.tabwidth;
+        let mut new_stop = (prev_stop + self.tabwidth) as i16;
+        let width = self.width - 1;
+        if new_stop > width { new_stop = width }
+        // 2. update cursor and return:
+        ((row * self.width) + new_stop) as usize
+    }
+
+    // Returns the index shifted left a col.
+    // Does NOT update internal index.
+    fn index_left(&self, index: usize, n: i16) -> usize { 0 }
+
+    // Returns the index shifted right a col.
+    // Does NOT update internal index.
+    fn index_right() {}
+
+    // Returns the index shifted up a row.
+    // Does NOT update internal index.
+    fn index_up() {}
+
+    // Returns the index shifted down a row.
+    // Does NOT update internal index.
+    fn index_down(&self, index: usize, n: i16) -> usize {
+        let mut n = n;
+        if n < 0 { n = n.abs() }
+        let (col, mut row) = self.coord(index);
+        let maxrow = self.height - 1;
+        if row + n >= maxrow { row = maxrow } else { row += n }
+        self.index((col, row))
+    }
+
+    // Returns a cleaned index after bounds checking. Always provides
+    // an index at the beginning of a Cell (no Spacers).
+    // NOTE: this WILL update the internal index AFTER first setting
+    // `self.index` -- use with `coord`, `index`, and `tabstop`.
+    fn cursor(&mut self) -> usize {
+        match self.cells.get(self.index) {
+            Some(Cell::Linker(offset, _)) => self.index -= offset,
+            Some(_) => (),
             None => {
                 // Could be out-of-bounds.
                 let length = self.cells.len();
-                match self.capacity.cmp(&length) {
+                let capacity = (self.width * self.height) as usize;
+                match capacity.cmp(&length) {
                     // Scenario A: cell buffer length < capacity:
                     Ordering::Greater => {
                         // Pop from extra back into cells to get
                         // Label { Label }ack to len == capacity.
-                        let cycles = self.capacity - length;
+                        let cycles = capacity - length;
                         for _ in 0..cycles {
-                            self.cells.push(Default::default());
+                            self.cells.push(Cell::NIL);
                         }
                     },
                     // Scenario B: cell buffer length > capacity:
                     Ordering::Less => {
                         // Pop from cells into extra to get back
                         // to len == capacity.
-                        let cycles = length - self.capacity;
+                        let cycles = length - capacity;
                         for _ in 0..cycles {
                             self.cells.pop();
                         }
                     },
-                    _ => (),
+                    // Scenario C: no issues with buffer; cursor index just
+                    // out of bounds. Set cursor to last Cell in buffer:
+                    Ordering::Equal => {
+                        self.index = capacity - 1;
+                    },
                 }
-                // Scenario C: no issues with buffer; cursor index just
-                // out of bounds. Set cursor to last Cell in buffer:
-                index = self.capacity - 1;
-                self.cursor = index;
-                match self.cells[index].content {
-                    Content::Pointer(a, _) => a,
-                    _ => index
+                // Should always be a valid index after the above:
+                if let Cell::Linker(offset, _) = self.cells[self.index] {
+                    self.index -= offset;
                 }
             }
         }
+
+        self.index
     }
 
-    // pub fn next_idx(&mut self) -> usize {}
-    // pub fn prev_idx(&mut self)
 
-    pub fn patch(&mut self, s: &str) {
-        // 1. get cursor
-        let mut index = self.cursor();
-        // Simple case (ascii-only)
-        // let mut count = 0;
-        // let chars = s.chars();
-        // let patch = vec![];
-        // for ch in chars {
-        //     let cell = self.cells.get(index)
-        //     count += 1
-        // }
-        // Below: complex case with CJK and multi-cell unicode
-        // // 2. chunk the &str
-        // let graphemes: Vec<&str> = UnicodeGraphemes::graphemes(s, true).collect();
-        // // 3. iterate through chunks
-        // let mut patch_buffer = vec![];
-        // for s in graphemes {
-        //     match s.width() {
-        //         0 => patch_buffer.push(Content::Blank),
-        //         1 => patch_buffer.push(Content::Single(
-        //             s.chars().next().expect("Error patching Single"))),
-        //         2 => {
-        //             patch_buffer.push(Content::Double(
-        //                 s.chars().next().expect("Error patching Double")));
-        //             patch_buffer.push(Content::Pointer())
-        //         },
-        //         _ => Content::Complex(
-        //             s.chars().collect())
-        //     };
-        //     patch_content.push(content);
-        // }
+    fn compare(&mut self, this: &Cell, data: (&usize, &usize, &usize)) {
+        let that = &self.cells[index];
+        if this == that {
+            let size = std::mem::size_of_val(cluster);
+            if eq_memsize + size >= 8 {
+                let length = outstr.len();
+                outstr.truncate(length - eq_memsize);
+                self.edits.push(Edit::Content(outstr));
+                outstr = String::with_capacity(
+                    self.width as usize);
+            } else {
+                eq_memsize += size;
+                outstr.push(car);
+            }
+        } else {
+
+        }
     }
+
+    #[cfg(unix)]
+    pub fn parse(&mut self, s: &str) {
+        // let mut index = self.cursor();
+        // let mut outstr = String::with_capacity(self.width as usize);
+        // let mut offset = 0;
+        // let mut memory = 8;
+        struct ``(usize, usize, usize, String);
+        let
+
+        for cluster in UnicodeGraphemes::graphemes(s, true) {
+            let mut chars = cluster.chars().peekable();
+            if let Some(car) = chars.next() { match chars.peek() {
+                // A single grapheme - can be ascii, cjk, or escape seq:
+                // char.width() returns the character's displayed
+                // width in columns, or `None` if the character
+                // is a control character other than `'\x00'`.
+                None => match car.width() {
+                    // Ascii or CJK
+                    Some(w) => match w {
+                        0 => continue,
+                        1 => {
+                            index += w;
+                            let cell = Cell::Single{
+                                value: car,
+                                width: w,
+                                style: self.style
+                            };
+
+                            // Diff Cell
+                            // memsize = 0;
+                            // match compare {
+                            //     Cell::Single{value: ch, width: _, style: s} => (),
+                            //     Cell::Double{value: ch, width: _, style: s} => (),
+                            //     Cell::Vector{value: ch, width: _, style: s} => (),
+                            //     Cell::Linker(_, _) => unreachable!(),
+                            //     Cell::TAB => (),
+                            //     Cell::NIL => self.cells[index] = cell,
+                            // }
+                        },
+                        2 => {
+                            // parsed.push(Cell::Double{
+                            //     value: car,
+                            //     width: 2,
+                            //     style: self.style
+                            // });
+                            // parsed.push(Cell::Joiner(1, 1));
+                            // index += 2;
+                        },
+                        _ => continue,
+                    },
+                    // Escape character
+                    None => match car {
+                        '\t' => {
+                            // parsed.push(Cell::TAB);
+                            // let n = self.tabstop(
+                            //     self.coord(index)) - index;
+                            // for i in 0..n {
+                            //     let m = i + 1;
+                            //     let (left, right) = (m, n - m);
+                            //     parsed.push(Cell::Joiner(left, right));
+                            // }
+                            // index += n;
+                        },
+                        '\n' => {
+                            // #[cfg(unix)] { index = self.index_down(index, 1) }
+                            // // LF (`\n`) is treated like CRLF (`\r\n`)
+                            // #[cfg(windows)] {
+                            //     let row = (index as i16) / width + 1;
+                            //     if self.height > row {
+                            //         index = self.index((0, row));
+                            //     } else {
+                            //         index = self.index((0, self.height - 1))
+                            //     }
+                            // }
+                            // // TODO: send parsed to edit table
+                            // // parsed.clear();
+                        },
+                        '\r' => {
+                            let row = (index as i16) / self.width;
+                            index = self.index((0, row));
+                            // TODO: send parsed to edit table
+                            // parsed.clear();
+                        },
+                        // '\x1B' => parsed.push(Cell::Single{
+                        //     value: '^',
+                        //     width: 1,
+                        //     style: self.style
+                        // }),
+                        _ => continue,
+                    }
+                },
+                Some(cadr) => (),
+            }}
+        }
+    }
+
+
+
+    //
+    // fn set_cell(&mut self, index: usize, cell: Cell, parsed: &mut Vec<Cell>) {
+    //     // 1. Push into the parsed buffer.
+    //     parsed.push(cell);
+    //     // 2. Get number of Spacers per Cell variant.
+    //     let coord = self.coord(index);
+    //     let width = match parsed.last().unwrap() {
+    //         Cell::Tab => self.tabstop(coord) - index,
+    //         #[cfg(unix)]
+    //         Cell::LineFeed => self.down(index, 1) - index,
+    //         #[cfg(windows)]
+    //         Cell::LineFeed => {},
+    //         Cell::Double{ value: _, width: _, style: _ } => {},
+    //         Cell::Scalar{ value: _, width: _, style: _ } => {},
+    //         // Spacer is never passed in as a parameter to be set.
+    //         // It gets automatically set via this function, therefore
+    //         // it is an unreachable variant in this match statement.
+    //         Cell::Spacer(_, _) => unreachable!(),
+    //         // Blank and Single
+    //         _ => 0,
+    //     }
+    //     // 3. Push each Spacer into the parsed buffer.
+    //     for i in 1..=width {
+    //         parsed.push(Cell::Spacer(i, width - i));
+    //     }
+    // }
+
 }
 
 
@@ -153,20 +330,21 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_grapheme_split() {
-        let string = "He㓘o, 👦🏿  👩‍🔬 क्‍ष \t \0 \r\n";
-        let graphemes: Vec<&str> = UnicodeGraphemes
-            ::graphemes(string, true).collect();
-
-        while let Some(s) = graphemes.next() {
-            let mut chars = s.chars.peekable();
-            for ch in chars {
-           }
-        }
+    fn test_() {
+        assert_eq!((2 + 2), 4)
     }
 
     #[test]
-    fn test_ascii_length() {
-        assert_eq!((2 + 2), 4)
+    fn test_ascii_buffer() {
+        // let input = "Hello, World!";
+        // let index = 18;
+        // let mut graphemes = UnicodeGraphemes::graphemes(input, true);
+        // while let Some(cluster) = graphemes.next() {
+        //     let mut chars = cluster.chars().peekable();
+        //     if let Some(car) = chars.next() { match chars.peek() {
+
+        //     }}
+        // }
     }
+
 }

--- a/src/terminal/store/buffer.rs
+++ b/src/terminal/store/buffer.rs
@@ -19,13 +19,12 @@ use crate::terminal::actions::win32;
 
 #[derive(Clone, PartialEq)]
 enum Cell {
-    Single{ value: char, width: usize, style: (Color, Color, u32) },
-    Double{ value: char, width: usize, style: (Color, Color, u32) },
-    Vector{ value: Vec<char>, width: usize, style: (Color, Color, u32) },
+    Single(char, usize, (Color, Color, u32)),
+    Double(char, usize, (Color, Color, u32)),
+    Vector(Vec<char>, usize, (Color, Color, u32)),
     // Linker is used for complex unicode values kept in a Vector. It
     // contains index offsets to the left and right from its position.
-    Linker(usize, usize),
-    TAB, NIL
+    Linker(usize, usize), NIL
 }
 
 
@@ -34,23 +33,25 @@ enum Cell {
 // e.g. windows (unused)
 // [ writeconsoleoutput{ rect }, writeconsoleoutput{ rect }, ... ]
 // In both cases, the cursor returns to where it needs to be after executing.
-enum Edit {
-    Index(usize),
-    Content(String),
-    Styling(Color, Color, u32),
-}
-
+// enum Edit {
+//     Index(usize),
+//     Content(String),
+//     // Styles(Color, Color, u32),
+// }
 
 pub struct Buffer {
     index: usize,
-    cells: Vec<Cell>,  // for get ch at point
-    edits: Vec<Edit>,  // for updating stdout
+    cells: Vec<Cell>,
+    strbuf: String,
+    #[cfg(windows)]
+    conbuf: Vec<CHAR_INFO>,
     width: i16,
     height: i16,
     style: (Color, Color, u32),
     tabwidth: usize,
     savedpos: usize,
-    // treatment: usize, // 0: no zwj; 1: zwj; 2: zwj+fitz; default: 0
+    use_winapi: bool,
+    wchar_mode: Option<bool>,
 }
 
 impl Buffer {
@@ -60,23 +61,106 @@ impl Buffer {
         #[cfg(windows)]
         let (width, height) = win32::size();
         let capacity = (width * height) as usize;
+
+        // TODO: run config to determine how the terminal
+        // renders complex unicode.
+        // None: No joiner support
+        //    eg. compound family takes 6 cells
+        //    eg. compound with fitzpatrick takes 12 cells
+        // Some(false): No fitzpatrick support
+        //    eg. compound family takes 2 cells
+        //    eg. compound with fitzpatrick takes 4 cells
+        // Some(true): Full support
+        //    eg. compound family takes 2 cells
+        //    eg. compound with fitzpatrick takes 2 cells
+
         Self {
             index: 0,
             cells: vec![Cell::NIL; capacity],
-            edits: Vec::with_capacity(12),
+            strbuf: String::with_capacity(capacity),
+            #[cfg(windows)]
+            conbuf: vec![zeroed(); capacity],
             width,
             height,
             style: (Reset, Reset, Effect::Reset as u32),
-            tabwidth: 8,
+            tabwidth: 4,
             savedpos: 0,
-            // treatment: 0,
+            use_winapi: false,
+            wchar_mode: None,
         }
     }
 
-    // pub fn treatment(&mut self, level: usize) {
-    //     self.treatment = level;
-    // }
+    pub fn winapi(&mut self) { self.use_winapi = true }
+    pub fn tabsize(&mut self, n: usize) { self.tabwidth = n }
 
+    pub fn size(&self) -> (i16, i16) { (self.width, self.height) }
+    pub fn resize(&mut self, w: i16, h: i16) {
+        self.width = w;
+        self.height = h;
+        let capacity = (w * h) as usize;
+        self.cells.resize(capacity, Cell::NIL);
+    }
+
+    pub fn clear(&mut self, c: Clear) {
+        match c {
+            Clear::All => {
+                let capacity = (self.width * self.height) as usize;
+                self.cells = vec![Cell::NIL; capacity];
+                self.index = 0;
+            }
+            Clear::NewLn => {
+                let index = self.cursor();
+                let (w, (col, row)) = (self.width,
+                                       self.coord(index));
+                let (start, stop) = (
+                    ((row * w) + col) as usize,
+                    ((row + 1) * w) as usize );
+                for i in start..stop { self.cells[i] = Cell::NIL }
+            }
+            Clear::CurrentLn => {
+                let index = self.cursor();
+                let (w, (_, row)) = (self.width,
+                                     self.coord(index));
+                let (start, stop) = (
+                    (row * w) as usize,
+                    ((row + 1) * w) as usize );
+                for i in start..stop { self.cells[i] = Cell::NIL }
+                self.reindex(self.index((0, row)));
+            }
+            Clear::CursorUp => {
+                let index = self.cursor();
+                let (w, (col, row)) = (self.width,
+                                       self.coord(index));
+                let stop = ((row * w) + col) as usize;
+                for i in 0..stop { self.cells[i] = Cell::NIL }
+            }
+            Clear::CursorDn => {
+                let index = self.cursor();
+                let ((w, h), (col, row)) = (self.size(),
+                                            self.coord(index));
+                let (start, stop) = (
+                    ((row * w) + col) as usize,
+                    (w * h) as usize );
+                for i in start..stop { self.cells[i] = Cell::NIL }
+            }
+        }
+    }
+
+    // pub fn savedpos(&self) -> usize { self.savedpos }
+    pub fn markpos(&mut self, i: usize) { self.savedpos = i }
+    pub fn gotomark(&mut self) {
+        let index = self.cursor();
+        self.reindex(self.savedpos);
+        self.savedpos = index;
+    }
+
+    pub fn style(&mut self, s: (Color, Color, u32)) { self.style = s }
+    pub fn style_fg(&mut self, c: Color) { self.style.0 = c }
+    pub fn style_bg(&mut self, c: Color) { self.style.1 = c }
+    pub fn style_fx(&mut self, f: u32) { self.style.2 = f }
+
+    // Buffer navigation specific functions.
+    //
     // Returns a coordinate tuple from an index.
     // Does NOT update internal index.
     pub fn coord(&self, index: usize) -> (i16, i16) {
@@ -109,37 +193,68 @@ impl Buffer {
 
     // Returns the index shifted left a col.
     // Does NOT update internal index.
-    fn index_left(&self, index: usize, n: i16) -> usize { 0 }
+    pub fn index_left(&self, index: usize, n: i16) -> usize {
+        if n < 0 { return self.index_right(index, n.abs()) }
+        let (col, row) = self.coord(index);
+        let mincol = 0;
+        let newcol = col - n;
+        if newcol <= mincol {
+            self.index((mincol, row))
+        } else {
+            self.index((newcol, row))
+        }
+    }
 
     // Returns the index shifted right a col.
     // Does NOT update internal index.
-    fn index_right() {}
+    pub fn index_right(&self, index: usize, n: i16) -> usize {
+        if n < 0 { return self.index_left(index, n.abs()) }
+        let (col, row) = self.coord(index);
+        let maxcol = self.width - 1;
+        let newcol = col + n;
+        if newcol >= maxcol {
+            self.index((maxcol, row))
+        } else {
+            self.index((newcol, row))
+        }
+    }
 
     // Returns the index shifted up a row.
     // Does NOT update internal index.
-    fn index_up() {}
+    pub fn index_up(&self, index:usize, n: i16) -> usize {
+        if n < 0 { return self.index_down(index, n.abs()) }
+        let (col, row) = self.coord(index);
+        let minrow = 0;
+        let newrow = row - n;
+        if newrow <= minrow {
+            self.index((col, minrow))
+        } else {
+            self.index((col, newrow))
+        }
+    }
 
     // Returns the index shifted down a row.
     // Does NOT update internal index.
-    fn index_down(&self, index: usize, n: i16) -> usize {
-        let mut n = n;
-        if n < 0 { n = n.abs() }
-        let (col, mut row) = self.coord(index);
+    pub fn index_down(&self, index: usize, n: i16) -> usize {
+        if n < 0 { return self.index_up(index, n.abs()) }
+        let (col, row) = self.coord(index);
         let maxrow = self.height - 1;
-        if row + n >= maxrow { row = maxrow } else { row += n }
-        self.index((col, row))
+        let newrow = row + n;
+        if newrow >= maxrow {
+            self.index((col, maxrow))
+        } else {
+            self.index((col, newrow))
+        }
     }
 
-    // Returns a cleaned index after bounds checking. Always provides
-    // an index at the beginning of a Cell (no Spacers).
-    // NOTE: this WILL update the internal index AFTER first setting
-    // `self.index` -- use with `coord`, `index`, and `tabstop`.
-    fn cursor(&mut self) -> usize {
+    // Returns a valid index after bounds checking. Always
+    // provides an index at the beginning of a Cell (no Linkers).
+    pub fn cursor(&mut self) -> usize {
         match self.cells.get(self.index) {
             Some(Cell::Linker(offset, _)) => self.index -= offset,
             Some(_) => (),
             None => {
-                // Could be out-of-bounds.
+                // Could be out-of-bounds. Fix len/cap issues.
                 let length = self.cells.len();
                 let capacity = (self.width * self.height) as usize;
                 match capacity.cmp(&length) {
@@ -161,12 +276,11 @@ impl Buffer {
                             self.cells.pop();
                         }
                     },
-                    // Scenario C: no issues with buffer; cursor index just
-                    // out of bounds. Set cursor to last Cell in buffer:
-                    Ordering::Equal => {
-                        self.index = capacity - 1;
-                    },
+                    // Scenario C: no issues with buffer:
+                    Ordering::Equal => (),
                 }
+                // Ensure index is valid after fixing buffer len/cap issues.
+                if self.index >= capacity { self.index = capacity - 1 }
                 // Should always be a valid index after the above:
                 if let Cell::Linker(offset, _) = self.cells[self.index] {
                     self.index -= offset;
@@ -177,37 +291,123 @@ impl Buffer {
         self.index
     }
 
-
-    fn compare(&mut self, this: &Cell, data: (&usize, &usize, &usize)) {
-        let that = &self.cells[index];
-        if this == that {
-            let size = std::mem::size_of_val(cluster);
-            if eq_memsize + size >= 8 {
-                let length = outstr.len();
-                outstr.truncate(length - eq_memsize);
-                self.edits.push(Edit::Content(outstr));
-                outstr = String::with_capacity(
-                    self.width as usize);
-            } else {
-                eq_memsize += size;
-                outstr.push(car);
-            }
-        } else {
-
-        }
+    // Update the index and returns the valid index.
+    pub fn reindex(&mut self, index: usize) -> usize {
+        self.index = index;
+        self.cursor()
     }
 
-    #[cfg(unix)]
-    pub fn parse(&mut self, s: &str) {
-        // let mut index = self.cursor();
-        // let mut outstr = String::with_capacity(self.width as usize);
-        // let mut offset = 0;
-        // let mut memory = 8;
-        struct ``(usize, usize, usize, String);
-        let
 
-        for cluster in UnicodeGraphemes::graphemes(s, true) {
-            let mut chars = cluster.chars().peekable();
+
+    // TODO: WINDOWS vs ANSI.
+
+    fn patch(&mut self, cell: Cell, index: usize, cutoff: usize) -> bool {
+        // TODO: WINDOWS
+        if self.use_winapi { return false }
+
+        let mut reset_cutoff = false;
+        let that = &self.cells[index];
+        // Handles only different cells.
+        if &cell != that {
+
+            // NOTE: Style would already be handled
+            // since self.style and the corresponding
+            // ansi string would be set upon calling
+            // `set_fg/bg/fx/styles`.
+           
+            // Handle output contents.
+            // Check consecutive unchanged Cells.
+            if cutoff > 8 {
+                // 1. Truncate the output strbuf.
+                let len = self.strbuf.len();
+                // Check if output will be empty after
+                // truncation, if not, push it, else, skip.
+                if len.saturating_sub(cutoff) > 0 {
+                    self.strbuf.truncate(len - cutoff);
+                }
+                // 2. Send a Goto escape sequence.
+                let (col, row) = self.coord(index);
+                let goto = format!("\x1B[{};{}H", row, col);
+                self.strbuf.push_str(&goto);
+                // 3. Restore the last char that was truncated.
+                match &cell {
+                    Cell::Single(ch, ..) => self.strbuf.push(*ch),
+                    Cell::Double(ch, ..) => self.strbuf.push(*ch),
+                    Cell::Vector(chs,..) => for ch in chs {
+                        self.strbuf.push(*ch)
+                    },
+                    Cell::NIL => self.strbuf.push(' '),
+                    Cell::Linker(..) => (),
+                }
+            }
+            // Reset the cutoff anytime we change the index or
+            // Cells are different.
+            reset_cutoff = true;
+            // Handle internal cell buffer.
+            // Replace Linkers for NIL.
+            match *that {
+                Cell::Single(..) => (),
+                Cell::Double(..) => {
+                    self.cells[index + 1] = Cell::NIL;
+                },
+                Cell::Vector(_, w, _) => {
+                    for i in 0..w {
+                        self.cells[index + i] = Cell::NIL;
+                    }
+                },
+                // Linker almost should be impossible to reach
+                // beacuse either (A) the call to `self.cursor`
+                // should place you at a top level Cell or (B)
+                // the prior iterations would have replaced Linkers
+                // with NILs. However, the case (C) is if there
+                // was an escape character (`\t`, `\n`, `\r`, etc)
+                // that caused the index to hit a Linker.
+                Cell::Linker(lhs, rhs) => {
+                    // Removes Linkers to the left including the
+                    // main Cell, but not the Cell at the index.
+                    for i in 1..=lhs {
+                        self.cells[index - i] = Cell::NIL;
+                    }
+                    // Removes Linkers to the right including the
+                    // Cell at index, but not the next main Cell.
+                    for i in 0..rhs {
+                        self.cells[index + i] = Cell::NIL;
+                    }
+                    // NOTE: for example:
+                    // a, b, c, [d, %, %], g, h
+                    //    ^         t
+                    // if ^ is the cursor and t is the tabstop
+                    // the linker @ t, will have a lhs of 1 and
+                    // a rhs of 2.
+                    // the first loop will clear the d:
+                    // i = (1..=1,) or (1) so [index - 1]
+                    // the second loop will clear the index
+                    // and the Linker next to it:
+                    // i = (0, 1,) so [index + 0] and [index + 1]
+                    // this way, when the current Cell gets swapped
+                    // with the new Cell, the wide cell will have
+                    // been cleared out.
+                },
+                Cell::NIL => (),
+            }
+            // Swap current index with new Cell.
+            self.cells[index] = cell
+        }
+
+        reset_cutoff
+    }
+
+    pub fn parse(&mut self, s: &str) {
+        let mut index: usize = self.cursor();
+        // Keep track of the memory size of consecutive unchanged Cells
+        // to truncate or cutoff once a changed Cell or the end of the
+        // iteration is reached. The threadhold is `8` or the size of
+        // a "goto" ansi sequence (`"\x1B[00;00H"`).
+        let mut cutoff: usize = 0;
+        // Index of the last diff or strbuf trunctation.
+        let mut freeze: usize = 0;
+        for grphm in UnicodeGraphemes::graphemes(s, true) {
+            let mut chars = grphm.chars().peekable();
             if let Some(car) = chars.next() { match chars.peek() {
                 // A single grapheme - can be ascii, cjk, or escape seq:
                 // char.width() returns the character's displayed
@@ -218,110 +418,117 @@ impl Buffer {
                     Some(w) => match w {
                         0 => continue,
                         1 => {
-                            index += w;
-                            let cell = Cell::Single{
-                                value: car,
-                                width: w,
-                                style: self.style
+                            cutoff += std::mem::size_of_val(grphm);
+                            self.strbuf.push(car);
+                            let cell = if car == ' ' {
+                                Cell::NIL
+                            } else {
+                                Cell::Single(car, 1, self.style)
                             };
-
-                            // Diff Cell
-                            // memsize = 0;
-                            // match compare {
-                            //     Cell::Single{value: ch, width: _, style: s} => (),
-                            //     Cell::Double{value: ch, width: _, style: s} => (),
-                            //     Cell::Vector{value: ch, width: _, style: s} => (),
-                            //     Cell::Linker(_, _) => unreachable!(),
-                            //     Cell::TAB => (),
-                            //     Cell::NIL => self.cells[index] = cell,
-                            // }
+                            let reset = self.patch(cell, index, cutoff);
+                            index += 1;
+                            if reset { cutoff = 0; freeze = index }
                         },
                         2 => {
-                            // parsed.push(Cell::Double{
-                            //     value: car,
-                            //     width: 2,
-                            //     style: self.style
-                            // });
-                            // parsed.push(Cell::Joiner(1, 1));
-                            // index += 2;
+                            cutoff += std::mem::size_of_val(grphm);
+                            self.strbuf.push(car);
+                            let cell = Cell::Double(car, 2, self.style);
+                            let reset = self.patch(cell, index, cutoff);
+                            self.cells[index + 1] = Cell::Linker(1, 1);
+                            index += 2;
+                            if reset { cutoff = 0; freeze = index }
                         },
                         _ => continue,
                     },
                     // Escape character
                     None => match car {
+                        // These update the cursor.
+                        // They do not overwrite or make content changes.
+                        // TODO: instead of hardcoding the CSI sequences
+                        // use ansi functions.
                         '\t' => {
-                            // parsed.push(Cell::TAB);
-                            // let n = self.tabstop(
-                            //     self.coord(index)) - index;
-                            // for i in 0..n {
-                            //     let m = i + 1;
-                            //     let (left, right) = (m, n - m);
-                            //     parsed.push(Cell::Joiner(left, right));
-                            // }
-                            // index += n;
+                            let tabbed = self.tabstop(self.coord(index));
+                            let offset = tabbed - index;
+                            if offset > 0 {
+                                let patch = format!("\x1B[{}C", offset);
+                                self.strbuf.push_str(&patch);
+                                // Updates to the strbuf resets the cutoff.
+                                cutoff = 0;
+                                index = tabbed;
+                                freeze = index;
+                            }
                         },
                         '\n' => {
-                            // #[cfg(unix)] { index = self.index_down(index, 1) }
-                            // // LF (`\n`) is treated like CRLF (`\r\n`)
-                            // #[cfg(windows)] {
-                            //     let row = (index as i16) / width + 1;
-                            //     if self.height > row {
-                            //         index = self.index((0, row));
-                            //     } else {
-                            //         index = self.index((0, self.height - 1))
-                            //     }
-                            // }
-                            // // TODO: send parsed to edit table
-                            // // parsed.clear();
+                            if self.use_winapi {
+                                // NOTE: `\n` is equal to `\r\n` this treats
+                                // them consistently...
+                                // TODO: Toggle between raw mode and cooked
+                                // mode treatments...
+                                // TODO: Windows simply needs to update index
+                                let (_, row) = self.coord(index);
+                                index = if self.height > row + 1 {
+                                    self.index((0, row + 1))
+                                } else {
+                                    self.index((0, self.height - 1))
+                                };
+                            } else {
+                                self.strbuf.push_str(&String::from("\x1B[B"));
+                                // Updates to the strbuf resets the cutoff.
+                                cutoff = 0;
+                                index = self.index_down(index, 1);
+                                freeze = index;
+                            };
                         },
                         '\r' => {
-                            let row = (index as i16) / self.width;
+                            let (col, row) = self.coord(index);
+                            let patch = format!("\x1B[{}D", col);
+                            self.strbuf.push_str(&patch);
+                            // Updates to the strbuf resets the cutoff.
+                            cutoff = 0;
                             index = self.index((0, row));
-                            // TODO: send parsed to edit table
-                            // parsed.clear();
+                            freeze = index;
                         },
-                        // '\x1B' => parsed.push(Cell::Single{
-                        //     value: '^',
-                        //     width: 1,
-                        //     style: self.style
-                        // }),
+                        '\x1B' => {
+                            cutoff += std::mem::size_of_val(grphm);
+                            self.strbuf.push('^');
+                            let cell = Cell::Single('^', 1, self.style);
+                            let reset = self.patch(cell, index, cutoff);
+                            index += 1;
+                            if reset { cutoff = 0; freeze = index }
+                        },
                         _ => continue,
                     }
                 },
                 Some(cadr) => (),
             }}
         }
+        // Truncate remaining cutoff, if any, from output string.
+        let len = self.strbuf.len();
+        if cutoff > 0 && len >= cutoff {
+            self.strbuf.truncate(len - cutoff);
+            index = freeze;
+        }
+        // Set index to the new index
+        self.reindex(index);
     }
 
+    #[cfg(test)]
+    pub fn flush(&mut self) -> String {
+        let output = self.strbuf.to_string();
+        self.strbuf.clear();
+        output
+    }
 
-
-    //
-    // fn set_cell(&mut self, index: usize, cell: Cell, parsed: &mut Vec<Cell>) {
-    //     // 1. Push into the parsed buffer.
-    //     parsed.push(cell);
-    //     // 2. Get number of Spacers per Cell variant.
-    //     let coord = self.coord(index);
-    //     let width = match parsed.last().unwrap() {
-    //         Cell::Tab => self.tabstop(coord) - index,
-    //         #[cfg(unix)]
-    //         Cell::LineFeed => self.down(index, 1) - index,
-    //         #[cfg(windows)]
-    //         Cell::LineFeed => {},
-    //         Cell::Double{ value: _, width: _, style: _ } => {},
-    //         Cell::Scalar{ value: _, width: _, style: _ } => {},
-    //         // Spacer is never passed in as a parameter to be set.
-    //         // It gets automatically set via this function, therefore
-    //         // it is an unreachable variant in this match statement.
-    //         Cell::Spacer(_, _) => unreachable!(),
-    //         // Blank and Single
-    //         _ => 0,
-    //     }
-    //     // 3. Push each Spacer into the parsed buffer.
-    //     for i in 1..=width {
-    //         parsed.push(Cell::Spacer(i, width - i));
-    //     }
-    // }
-
+    pub fn getch(&mut self) -> String {
+        let index = self.cursor();
+        match &self.cells[index] {
+            Cell::Single(ch, ..) => format!("{}", ch),
+            Cell::Double(ch, ..) => format!("{}", ch),
+            Cell::Vector(chs,..) => chs.iter().collect(),
+            Cell::NIL => String::from(" "),
+            Cell::Linker(..) => unreachable!()
+        }
+    }
 }
 
 
@@ -335,16 +542,79 @@ mod tests {
     }
 
     #[test]
-    fn test_ascii_buffer() {
-        // let input = "Hello, World!";
-        // let index = 18;
-        // let mut graphemes = UnicodeGraphemes::graphemes(input, true);
-        // while let Some(cluster) = graphemes.next() {
-        //     let mut chars = cluster.chars().peekable();
-        //     if let Some(car) = chars.next() { match chars.peek() {
-
-        //     }}
-        // }
+    fn test_tabstop() {
+        let mut buf = Buffer::new();
+        let index = buf.reindex(buf.index((15, 0)));
+        let tabbed = buf.tabstop((15, 0));
+        let offset = tabbed - index;
+        assert_eq!(tabbed, 16);
+        buf.reindex(tabbed);
+        assert_eq!(buf.cursor(), 16);
     }
 
+    #[test]
+    fn test_ascii_buffer_simple() {
+        // NOTE: ANSI
+        let mut buf = Buffer::new();
+        let original_input = "Hello, world!";
+        buf.parse(original_input);
+        buf.flush(); // probably want to write the output to stdout asap;
+        // NOTE: don't want the stfbuf getting wonky from multiple write ops.
+
+        let modified_input = "Bella, whale!";
+        buf.reindex(buf.index((0, 0)));
+        buf.parse(modified_input);
+        let output = buf.flush();
+        assert_eq!(String::from("Bella, whale"), output);
+        assert_eq!(buf.cursor(), 12);
+        assert_eq!("!", &buf.getch());
+
+        // Mimick goto:
+        buf.reindex(buf.index((5, 0)));
+        assert_eq!(",", &buf.getch());
+
+        let consecutive_input = "Hella, wharf!";
+        buf.reindex(buf.index((0, 0)));
+        buf.parse(consecutive_input);
+        let output = buf.flush();
+        assert_eq!(String::from("H\x1B[0;10Hrf"), output);
+    }
+
+    #[test]
+    fn test_ascii_buffer_complex() {
+        // NOTE: ANSI
+        let mut buf = Buffer::new();
+        let original_input = "Hello, world!\n\nH23\towdy, neighbor!";
+        buf.parse(original_input);
+        buf.flush();
+        // // Mimick goto:
+        buf.reindex(buf.index((12, 0)));
+        assert_eq!("!", &buf.getch());
+        buf.reindex(buf.index((13, 2)));
+        assert_eq!("H", &buf.getch());
+        buf.reindex(buf.index((14, 2)));
+        assert_eq!("2", &buf.getch());
+        buf.reindex(buf.index((15, 2)));
+        assert_eq!("3", &buf.getch());
+        buf.reindex(buf.index((20, 2)));
+        assert_eq!("o", &buf.getch());
+
+        buf.reindex(buf.index((13, 2)));
+        let modified_input = "B23\tella, nutrition!";
+        buf.parse(modified_input);
+        let output = buf.flush();
+        // NOTE: Below the cursor is at 16 so the next
+        // tabstop would be 20 or 4 cells away.
+        assert_eq!(String::from("B23\x1B[4Cella, nutrition!"), output);
+
+        buf.reindex(buf.index((26, 2)));
+        assert_eq!("n", &buf.getch());
+
+        buf.reindex(buf.index((13, 2)));
+        let repeated_input = "B23\tella, natrition!";
+        buf.parse(repeated_input);
+        let output = buf.flush();
+        assert_ne!(String::from("B23\x1B[4Cella, nutrition!"), output);
+        assert_eq!(String::from("B23\x1B[4Cella, na"), output);
+    }
 }

--- a/src/terminal/store/buffer.rs
+++ b/src/terminal/store/buffer.rs
@@ -1,10 +1,6 @@
 // This module provides an internal representation of the contents that
 // make up the terminal screen.
-use std::{
-    thread,
-    cmp::Ordering,
-    time::Duration,
-};
+use std::cmp::Ordering;
 
 use crate::common::{
     enums::{ Color::{*, self}, Effect, Style, Clear },
@@ -72,6 +68,7 @@ impl Buffer {
         }
     }
 
+    #[cfg(unix)]
     pub fn check_mod(&mut self) -> i16 {
         let test = &["🧗", "🏽", "\u{200d}", "♀", "\u{fe0f}"].concat();
         // TODO: Replace this once actions are unified
@@ -864,10 +861,15 @@ mod tests {
     // }
 
     #[test]
-    fn test_macos_mod_support() {
-        let mut buf = Buffer::new();
-        assert_eq!(buf.check_mod(), 2);
-        // buf.check_mod();
-        // assert_eq!(buf.is_mod(), true);
+    fn test_mod_support() {
+        if cfg!(target_os = "macos") {
+            let mut buf = Buffer::new();
+            assert_eq!(buf.check_mod(), 2);
+        } else if cfg!(target_os = "windows") {
+            ()
+        } else {
+            let mut buf = Buffer::new();
+            assert_eq!(buf.check_mod(), 5);
+        }
     }
 }

--- a/src/terminal/store/buffer.rs
+++ b/src/terminal/store/buffer.rs
@@ -1,0 +1,172 @@
+// This module provides an internal representation of the contents that
+// make up the terminal screen.
+use std::cmp::Ordering;
+
+use crate::common::{
+    enums::{ Color::{*, self}, Effect, Style, Clear },
+    unicode::{
+        wcwidth::UnicodeWidthChar,
+        grapheme::UnicodeGraphemes,
+    },
+};
+
+#[cfg(unix)]
+use crate::terminal::actions::posix;
+
+#[cfg(windows)]
+use crate::terminal::actions::win32;
+
+
+#[derive(Clone)]
+enum Content {
+    Single(char),
+    Double(char),
+    Complex(Vec<char>),
+    Pointer(usize, usize),
+    Blank,
+}
+
+
+#[derive(Clone)]
+pub struct Cell {
+    content: Content,
+    style: (Color, Color, u32),
+    is_dirty: bool,
+}
+
+impl Default for Cell {
+    fn default() -> Self {
+        Self {
+            content: Content::Blank,
+            style: (Reset, Reset, Effect::Reset as u32),
+            is_dirty: false
+        }
+    }
+}
+
+
+pub struct Buffer {
+    cursor: usize,
+    cells: Vec<Cell>,
+    capacity: usize,
+    // window: (i16, i16),
+    // tab_size: usize,
+    // marked_pos: usize,
+    // active_style: (Color, Color, u32)
+}
+
+impl Buffer {
+    pub fn new() -> Self {
+        #[cfg(unix)]
+        let (w, h) = posix::size();
+        #[cfg(windows)]
+        let (w, h) = win32::size();
+        let cursor = 0;
+        let capacity = (w * h) as usize;
+        let cells = vec![Default::default(); capacity];
+        Self { cursor, cells, capacity }
+    }
+
+    pub fn cursor(&mut self) -> usize {
+        let mut index = self.cursor;
+        match self.cells.get(index) {
+            Some(c) => match c.content {
+                Content::Pointer(a, _) => a,
+                _ => index
+            },
+            None => {
+                // Could be out-of-bounds.
+                let length = self.cells.len();
+                match self.capacity.cmp(&length) {
+                    // Scenario A: cell buffer length < capacity:
+                    Ordering::Greater => {
+                        // Pop from extra back into cells to get
+                        // Label { Label }ack to len == capacity.
+                        let cycles = self.capacity - length;
+                        for _ in 0..cycles {
+                            self.cells.push(Default::default());
+                        }
+                    },
+                    // Scenario B: cell buffer length > capacity:
+                    Ordering::Less => {
+                        // Pop from cells into extra to get back
+                        // to len == capacity.
+                        let cycles = length - self.capacity;
+                        for _ in 0..cycles {
+                            self.cells.pop();
+                        }
+                    },
+                    _ => (),
+                }
+                // Scenario C: no issues with buffer; cursor index just
+                // out of bounds. Set cursor to last Cell in buffer:
+                index = self.capacity - 1;
+                self.cursor = index;
+                match self.cells[index].content {
+                    Content::Pointer(a, _) => a,
+                    _ => index
+                }
+            }
+        }
+    }
+
+    // pub fn next_idx(&mut self) -> usize {}
+    // pub fn prev_idx(&mut self)
+
+    pub fn patch(&mut self, s: &str) {
+        // 1. get cursor
+        let mut index = self.cursor();
+        // Simple case (ascii-only)
+        // let mut count = 0;
+        // let chars = s.chars();
+        // let patch = vec![];
+        // for ch in chars {
+        //     let cell = self.cells.get(index)
+        //     count += 1
+        // }
+        // Below: complex case with CJK and multi-cell unicode
+        // // 2. chunk the &str
+        // let graphemes: Vec<&str> = UnicodeGraphemes::graphemes(s, true).collect();
+        // // 3. iterate through chunks
+        // let mut patch_buffer = vec![];
+        // for s in graphemes {
+        //     match s.width() {
+        //         0 => patch_buffer.push(Content::Blank),
+        //         1 => patch_buffer.push(Content::Single(
+        //             s.chars().next().expect("Error patching Single"))),
+        //         2 => {
+        //             patch_buffer.push(Content::Double(
+        //                 s.chars().next().expect("Error patching Double")));
+        //             patch_buffer.push(Content::Pointer())
+        //         },
+        //         _ => Content::Complex(
+        //             s.chars().collect())
+        //     };
+        //     patch_content.push(content);
+        // }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_grapheme_split() {
+        let string = "He㓘o, 👦🏿  👩‍🔬 क्‍ष \t \0 \r\n";
+        let graphemes: Vec<&str> = UnicodeGraphemes
+            ::graphemes(string, true).collect();
+
+        while let Some(s) = graphemes.next() {
+            let mut chars = s.chars.peekable();
+            for ch in chars {
+           }
+        }
+    }
+
+    #[test]
+    fn test_ascii_length() {
+        assert_eq!((2 + 2), 4)
+    }
+}

--- a/src/terminal/store/cell.rs
+++ b/src/terminal/store/cell.rs
@@ -267,11 +267,11 @@ impl ScreenBuffer {
                 self.cursor = index + 2;
             },
             false => {
-                let mut placeholder = false;
+                let mut partial = false;
                 // If cell below is wide and new cell is single,
-                // we would need to clear out the placeholder cell.
+                // we would need to clear out the partial cell.
                 if let Some(cell) = &self.cells[index] {
-                    if cell.is_wide { placeholder = true }
+                    if cell.is_wide { partial = true }
                 }
                 self.cells.remove(index);
                 self.cells.insert(index, Some(Cell {
@@ -281,7 +281,7 @@ impl ScreenBuffer {
                     style: self.active_style,
                 }));
                 self.cursor = index + 1;
-                if placeholder {
+                if partial {
                     self.cells.remove(index + 1);
                     self.cells.insert(index + 1, None);
                     self.cursor = index + 2;

--- a/src/terminal/store/cell.rs
+++ b/src/terminal/store/cell.rs
@@ -541,7 +541,6 @@ impl ScreenBuffer {
             words.push((current, change_index, index - 1));
         }
 
-        // TODO: move the below into actions
         for set in words {
             let (word, start, finish) = set;
             let length = (finish - start) as u32;
@@ -550,22 +549,6 @@ impl ScreenBuffer {
                 finish as i16 / self.width()
             );            
             win32::set_attrib(word, length, coord);
-
-
-            // let err = unsafe {
-            //     WriteConsoleOutputAttribute(
-            //         altern.0,
-            //         styles.as_ptr() as *const WORD,
-            //         length as u32,
-            //         COORD { X: col, Y: row},
-            //         &mut count
-            //     )
-            // };
-            // if err == 0 {
-            //     tuitty::terminal::actions::win32::cook();
-            //     tuitty::terminal::actions::win32::disable_alt(false);
-            //     panic!(format!("Something went wrong applying attr to buffer - response: {}", err));
-            // }
         }
         win32::goto(col, row, vte);
     }

--- a/src/terminal/store/mod.rs
+++ b/src/terminal/store/mod.rs
@@ -1,6 +1,7 @@
 // This module provides the Store which synchronizes application state with
 // dispatched user actions and maintains settings across each "screen".
 
+mod buffer;
 mod cell;
 use cell::ScreenBuffer;
 

--- a/src/terminal/store/mod.rs
+++ b/src/terminal/store/mod.rs
@@ -1,7 +1,7 @@
 // This module provides the Store which synchronizes application state with
 // dispatched user actions and maintains settings across each "screen".
 
-mod buffer;
+// mod buffer;
 mod cell;
 use cell::ScreenBuffer;
 

--- a/src/terminal/store/mod.rs
+++ b/src/terminal/store/mod.rs
@@ -66,7 +66,6 @@ impl Store {
     }
 
     pub fn size(&self) -> (i16, i16) {
-        // TODO: tput size? see: crossterm/issue/276
         if let Some(s) = self.data.get(self.id) {
             s.buffer.size()
         } else { (0, 0) }


### PR DESCRIPTION
**Feature Description**
We want to be able to store character information so that a User can retrieve character information with something akin to a `getch`. We also want to allow switching of buffers or screens that restore previous content between them. 

What gets tricky is the character support between terminals and how to efficiently render a screen with both text and styles on windows and unix terminals.

**Solution**

- [x]  We are going to keep an internal representation of each available cell of the terminal. This internal buffer will contain both 1-cell and 2-cell wide characters and has methods that allows for it to keep in sync with the cursor position. On both windows and posix terminals we iterate through the buffer and build a single `String` to restore the buffer. 

- We had originally intended it to "patch" various diffs across the screen, but felt that it wasn't necessary, as the terminal window usually is of a fixed size and actually calling multiple patches would actually degrade performance because you would be calling `stdout` multiple times instead of a single time. 

- [x] For Posix systems, the styles would be represented as ANSI strings so that would just be added to the final output String to be printed and flushed. 
- [x] However, on Windows, there we needed to iterate through styles and call `WriteConsoleOutputAttribute` to render styles on preexisting text (if we wanted to reduce the amount of printing calls).

- We had intended to use `ReadConsoleOutput` and `WriteConsoleOutput` accordingly for a built in Windows inner buffer, but it seemed that this buffer did not support unicode characters. Therefore, even though we were able to print emojis, upon restore, they would disappear with these API calls.

- [x] We also made a decision to limit emojis to **_only non-combiner characters_**. This means that a majority of emojis will work, but skin tones, gender modifiers, hair modifiers, and other combination emojis using `\u{200d}` **_will not_** be supported.

* This was because, on multiple OS's, complex emoji support is all over the place. 
  * On MacOS, most emojis are supported with skin tone emojis rendering correctly as 2-cell wide characters. 
  * However, on Linux terminals (konsole, gnome terminal, alacritty, xterm, etc) it all depended on settings and terminal emulators. Almost all of them could render regular emojis, but skin tones and other modifiers would render an additional 1- or 2-cell wide character. 
  * On Windows, fuggeddaboutit. The best terminal emulator is the new Windows Terminal. While it has "support" for most emojis, it struggles with complex ones -- especially with almost random sizes, spacing, and heights.

This variation was the reason why this feature has taken so long... 

So, with really no consistency across the board, we made the decision to reduce down to only non-combiner emojis (which TBH is enough). There won't be further support, until emojis are widely standardized. 

- [x] For all complex emojis that get into the buffer, they will be replaced with this emoji: 🚧
- [x] This placeholder can be modified by the User

- [ ] There is still needed work to catch complex emojis at time of input so that it doesn't even render even if you decide to type it in yourself. 
- [ ] One "improvement" that I will do is to keep track of multi spaced emojis and allow for the return of them upon calling `getch`. This is not included in this PR.

**Additional Stuff**

- [x] Addressed #13 
- [x] Added a `set_attrib` function to call `WriteConsoleOutputAttribute`
- [ ] Can also address #11 but need to make the methods public
- [ ] Can also fix #7 

Addressing #8 next to resolve the issues above in aggregate. 
Addressing #14 after #8
